### PR TITLE
🐞 Fix: Invalid box-shadow in .template-card class

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -292,7 +292,7 @@ body.dark .info-section p {
 .template-card {
   background: var(--card-bg);
   border-radius: 1.1rem;
-  box-shadow: black;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.25);
   padding: 2rem 1.2rem 1.5rem 1.2rem;
   display: flex;
   flex-direction: column;

--- a/styles.css
+++ b/styles.css
@@ -299,14 +299,10 @@ body.dark .info-section p {
   align-items: center;
   opacity: 0;
   transform: translateY(40px);
-
-  
   animation: none;
   position: relative;
   overflow: hidden;
-
   transition: opacity 0.7s, transform 0.7s;
-
 }
 
 .template-card.visible {


### PR DESCRIPTION
# 🚀 Pull Request

## 📄 Description
Fixes #77 

This PR fixes an invalid `box-shadow` value in the `.template-card` class in `styles.css`.

## 🛠️ Type of Change
- [x] Bug fix 🐛
- [ ] New feature ✨
- [ ] Code refactor 🔨
- [ ] Documentation update 📚
- [ ] Other (please describe):

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have linked the issue using `Fixes #52`

## 📸 Screenshots (if available)
<img width="1440" height="900" alt="Screenshot 2025-07-22 at 8 03 29 PM" src="https://github.com/user-attachments/assets/3879226f-420a-4cf6-b715-4382020a7d2c" />


## 📚 Related Issues
- Original issue: #77

## 🧠 Additional Context
Previously, the `.template-card` had `box-shadow: black;` which is invalid.  
It has now been replaced with:
```css
box-shadow: 0 2px 10px rgba(0, 0, 0, 0.25);