### PR TITLE
Fix: Correct template card shadow & remove duplicate button styles (#77): styles.css

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -5,6 +5,7 @@
   box-sizing: border-box;
 }
 :root {
+  --secondary: #2563eb;
   --primary-bg: #f9f9f9;
   --primary-text: #222;
   --accent: #4f8cff;
@@ -292,7 +293,7 @@ body.dark .info-section p {
 .template-card {
   background: var(--card-bg);
   border-radius: 1.1rem;
-  box-shadow: black;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
   padding: 2rem 1.2rem 1.5rem 1.2rem;
   display: flex;
   flex-direction: column;
@@ -346,24 +347,6 @@ body.dark .info-section p {
 
 .template-card:hover .template-preview {
   transform: scale(1.05);
-}
-
-.template-btn {
-  margin-top: 1rem;
-  padding: 0.6rem 1.2rem;
-  border: none;
-  border-radius: 0.6rem;
-  background-color: var(--accent);
-  color: white;
-  font-weight: 600;
-  text-decoration: none;
-  transition: background-color 0.3s ease, transform 0.3s ease;
-}
-
-.template-btn:hover {
-  transform: translateY(-2px);
-  background-color: var(--accent); 
-  opacity: 1;
 }
 
 /* Preview styles */


### PR DESCRIPTION
# 🚀 Pull Request

## 📄 Description
This PR fixes the incorrect box-shadow value used in the .template-card class and removes a duplicate .template-btn style block to prevent style conflicts and maintain code clarity.
Fixes #77
#77 – Fix incorrect box-shadow on .template-card
Changed box-shadow: black; to box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);

Resolved visual bug affecting template card styling.
Duplicate .template-btn style block
Removed an older or duplicate block of .template-btn to avoid conflicting styles.
Ensured consistency and cleaned up the CSS file.

## 🛠️ Type of Change
- [ ] Bug fix 🐛

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have linked the issue using `Fixes #77 `

## 📸 Screenshots (if available)
N/A (Visual style improvement, small enough not to need screenshots)

## 📚 Related Issues
None

## 🧠 Additional Context
This addresses a visual inconsistency reported in #77 and helps keep the CSS clean and maintainable.