### PR TITLE
Added placeholders to contact form

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -36,22 +36,22 @@
         <form class="contact-form">
           <div class="form-group">
             <label for="name">Name</label>
-            <input type="text" id="name" name="name" required>
+            <input type="text" id="name" name="name" placeholder="Enter your name" required>
           </div>
 
           <div class="form-group">
             <label for="email">Email</label>
-            <input type="email" id="email" name="email" required>
+            <input type="email" id="email" name="email" placeholder="Enter your email (for eg. john@gmail.com)" required>
           </div>
 
           <div class="form-group">
             <label for="subject">Subject</label>
-            <input type="text" id="subject" name="subject" required>
+            <input type="text" id="subject" name="subject" placeholder = "Enter the subject" required>
           </div>
 
           <div class="form-group">
             <label for="message">Message</label>
-            <textarea id="message" name="message" rows="5" required></textarea>
+            <textarea id="message" name="message" rows="5" placeholder="Enter the message you want to convey" required></textarea>
           </div>
           <div class="contact-button">
             <button type="submit" class="submit-btn">Send Message</button>


### PR DESCRIPTION
Added Placeholder to the Contact form which will provide clear description to users what to enter in that field.
<img width="1600" height="694" alt="image" src="https://github.com/user-attachments/assets/437fa5a2-c1b4-4ad9-8f32-2af2a5310413" />
Please merge this request
Solved issue #147 


