### PR TITLE
Fix: Template section headings are now visible in dark mode

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1001,3 +1001,13 @@ body.dark .submit-btn.disabled:hover {
   transition: transform 0.2s ease;
   will-change: transform, left, top;
 }
+
+/* Fix template headings in dark mode */
+body.dark .templates-main h1 {
+  color: #f3f3f3;
+}
+
+body.dark .template-card h2 {
+  color: #f3f3f3;
+}
+


### PR DESCRIPTION
This PR fixes an issue where the headings in the Templates section were not visible in dark mode due to hardcoded black text. Added body.dark CSS overrides to make these headings bright and readable when dark theme is enabled.

Fixes #96 