### PR TITLE
Added placeholders in contact form fields

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -35,22 +35,22 @@
         <form class="contact-form">
           <div class="form-group scroll-fade">
             <label for="name">Name</label>
-            <input type="text" id="name" name="name" required>
+            <input type="text" id="name" name="name" placeholder = "Enter your name" required>
           </div>
 
           <div class="form-group scroll-fade">
             <label for="email">Email</label>
-            <input type="email" id="email" name="email" required>
+            <input type="email" id="email" name="email"placeholder = "Enter your email id (e.g. john@gmail.com)" required>
           </div>
 
           <div class="form-group scroll-fade">
             <label for="subject">Subject</label>
-            <input type="text" id="subject" name="subject" required>
+            <input type="text" id="subject" name="subject"placeholder = "Enter the subject" required>
           </div>
 
           <div class="form-group scroll-fade">
             <label for="message">Message</label>
-            <textarea id="message" name="message" rows="5" required></textarea>
+            <textarea id="message" name="message" rows="5"placeholder = "Enter the message you want to convey" required></textarea>
           </div>
 
           <div class="contact-button scroll-fade">


### PR DESCRIPTION
I have added placeholders in contact form fields so that it gives detailed description to users about what to enter in the fields.

<img width="1858" height="860" alt="image" src="https://github.com/user-attachments/assets/8bdd22fa-68df-4edd-8d99-c984bebc23f4" />


Please merge this request.
Solved issue #147 
