### PR TITLE
Fix: Back Button beside Templates Gallery

### DIFF
--- a/contributors.html
+++ b/contributors.html
@@ -11,6 +11,33 @@
     .contributors-main {
       margin-bottom: 10rem;
     }
+    .template-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding-left: 16px;
+  margin-bottom: 20px;
+}
+
+.back-btn {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background-color: #333;
+  color: white;
+  font-size: 20px;
+  text-decoration: none;
+  border: 1px solid #666;
+  transition: background-color 0.3s ease;
+}
+
+.back-btn:hover {
+  background-color: #555;
+}
+
   </style>
 </head>
 
@@ -34,6 +61,7 @@
   </nav>
 
   <main class="contributors-main scroll-fade">
+    <a href="javascript:history.back()" class="back-btn" aria-label="Go Back">←</a>
     <h1 class="fade-in">Meet Our Contributors</h1>
     <div id="contributors-grid" class="templates-grid scroll-fade">
       <!-- Cards get populated dynamically -->

--- a/styles.css
+++ b/styles.css
@@ -1001,3 +1001,13 @@ body.dark .submit-btn.disabled:hover {
   transition: transform 0.2s ease;
   will-change: transform, left, top;
 }
+
+/* Fix template headings in dark mode */
+body.dark .templates-main h1 {
+  color: #f3f3f3;
+}
+
+body.dark .template-card h2 {
+  color: #f3f3f3;
+}
+

--- a/templates.html
+++ b/templates.html
@@ -206,10 +206,36 @@ body.dark-theme .hero-preview {
 .hero-preview .hero-text-line.short {
   width: 50%;
 }
+.template-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding-left: 16px;
+  margin-bottom: 20px;
+}
+
+.back-btn {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background-color: #333;
+  color: white;
+  font-size: 20px;
+  text-decoration: none;
+  border: 1px solid #666;
+  transition: background-color 0.3s ease;
+}
+
+.back-btn:hover {
+  background-color: #555;
+}
 
 
-     
-    </style>
+  
+  </style>
   </head>
   <body>
     <nav class="navbar">
@@ -230,6 +256,7 @@ body.dark-theme .hero-preview {
 
 
     <main class="templates-main">
+      <a href="javascript:history.back()" class="back-btn" aria-label="Go Back">←</a>
       <h1>Templates Gallery</h1>
       <section class="templates-grid">
         <article class="template-card">


### PR DESCRIPTION
Added a responsive back button placed in Templates page and Contributors page and added styles for both light and dark mode 

<img width="1919" height="851" alt="image" src="https://github.com/user-attachments/assets/3ddbabd5-65aa-4164-b179-17eff6b14105" />

closes #97 


