### PR TITLE
Fix: Template section headings are now visible in dark mode

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1001,3 +1001,13 @@ body.dark .submit-btn.disabled:hover {
   transition: transform 0.2s ease;
   will-change: transform, left, top;
 }
+
+/* Fix template headings in dark mode */
+body.dark .templates-main h1 {
+  color: #f3f3f3;
+}
+
+body.dark .template-card h2 {
+  color: #f3f3f3;
+}
+


### PR DESCRIPTION
This PR ensures that template section headings are clearly visible when dark mode is enabled by applying appropriate color adjustments.

Previously addressed in PR #183 but lost due to fork deletion. This is a clean re-PR.

✅ Dark mode styles updated  
✅ Verified in both light and dark themes

closes #96 