### PR TITLE
Fix: Correct GitHub Contributors API Endpoint for Live Data

### DIFF
--- a/script.js
+++ b/script.js
@@ -82,7 +82,7 @@ window.addEventListener('DOMContentLoaded', () => {
   // 🧑‍💻 Contributors fetch
   const contributorsGrid = document.getElementById('contributors-grid');
   if (contributorsGrid) {
-    fetch('https://api.github.com/repos/AnujShrivastava01/AnimateItNow/contributors')
+    fetch('https://api.github.com/repos/itsAnimation/AnimateItNow/contributors')
       .then(res => res.json())
       .then(contributors => {
         contributorsGrid.innerHTML = '';


### PR DESCRIPTION
# 🚀 Pull Request

## 📄 Description  
Fixed the broken contributors section by updating the GitHub API URL to the correct repository: `itsAnimation/AnimateItNow`.

Fixes #197

## 🛠️ Type of Change  
- [x] Bug fix 🐛  

## ✅ Checklist  
- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have added tests that prove my fix is effective or that my feature works  
- [x] I have linked the issue using `Fixes #issue_number` (if applicable)  

## 📸 Screenshots (if available)  
<img width="1919" height="967" alt="image" src="https://github.com/user-attachments/assets/9875b033-c7b8-466d-8e70-f55a60c82dce" />

## 📚 Related Issues  
- N/A

## 🧠 Additional Context  
This fix enables real-time contributor data to be fetched and displayed correctly on the site using the GitHub API.