### PR TITLE
Update styles.css

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -24,8 +24,8 @@
 
 body {
   font-family: "Segoe UI", Arial, sans-serif;
-  /* background: url("images/bg.jpg") no-repeat center center fixed; */
-  /* background-size: cover; */
+  background: url("images/bg.jpg") no-repeat center center fixed;
+  background-size: cover;
   background-color: var(--primary-bg);
   color: var(--primary-text);
   transition: background var(--transition), color var(--transition);
@@ -40,7 +40,7 @@ body {
 }
 
 .list-group-item {
-  background-color: #f1f1f1;
+  background-color: #f9f9f9;
   margin: 8px 0;
   padding: 12px 16px;
   border-radius: 8px;
@@ -318,15 +318,16 @@ body {
 
 /* Landing Section */
 .landing-section {
-  height: 100vh;
+  /* background: url("images/bg.jpg") center center / cover no-repeat; */
+  min-height: 100vh;
   width: 100%;
-  background: url("images/bg.jpg") center center / cover no-repeat;
-  background-attachment: fixed;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
   text-align: center;
+  padding: 2rem;
+  color: var(--text-color); /* if you're using CSS variables */
 }
 
 .landing-section::after {


### PR DESCRIPTION
📄 Description
This PR fixes the issue where the homepage background image in light mode did not cover the full viewport, unlike in dark mode. The update ensures the image spans the entire screen for a uniform and responsive layout.

Fixes: #390

🛠️ Type of Change
 Bug fix 🐛

✅ Checklist
 My code follows the style guidelines of this project

 I have performed a self-review of my code

 I have commented my code, particularly in hard-to-understand areas

 I have added tests that prove my fix is effective or that my feature works

 I have linked the issue using Fixes #390

📸 Screenshots
Before:
<img width="1905" height="823" alt="image" src="https://github.com/user-attachments/assets/e25c6269-06c0-4c72-9ec6-06f0576d4714" />


After:
<img width="1792" height="760" alt="image" src="https://github.com/user-attachments/assets/5f2abc26-6d1d-4712-888f-93ebb6471486" />


