### PR TITLE
added feature: copy-button in templates

### DIFF
--- a/templates/display.html
+++ b/templates/display.html
@@ -29,13 +29,14 @@
         <h3>Display: Inline</h3>
         <div class="demo-preview">
           <p>This is <span style="display:inline; background:#fde2e4; padding:4px; border-radius:4px;">an inline span</span> within a paragraph.</p>
-<p style="opacity:0.7;">Inline elements stay on the same line and don't break flow.</p>
-
+          <p style="opacity:0.7;">Inline elements stay on the same line and don't break flow.</p>
         </div>
         <button class="expand-btn" onclick="toggleCode(this)">Show Code</button>
-        <div class="code-block">
+        <div class="code-wrapper" style="position:relative;">
+          <pre class="code-block">
 &lt;p&gt;This is &lt;span style="display:inline; background:#ffeb3b; padding:4px;"&gt;an inline span&lt;/span&gt; within a paragraph.&lt;/p&gt;
 &lt;p&gt;Inline elements stay on the same line and don't break flow.&lt;/p&gt;
+          </pre>
         </div>
       </div>
 
@@ -43,15 +44,16 @@
         <h3>Display: Block</h3>
         <div class="demo-preview">
           <div style="display:block; background:#cdeffd; color:#333; padding:10px; margin-bottom:6px; border-radius:6px;">Block Element 1</div>
-<div style="display:block; background:#d0f4de; color:#333; padding:10px; border-radius:6px;">Block Element 2</div>
-<p style="opacity:0.7;">Block elements take full width and start on a new line.</p>
-
+          <div style="display:block; background:#d0f4de; color:#333; padding:10px; border-radius:6px;">Block Element 2</div>
+          <p style="opacity:0.7;">Block elements take full width and start on a new line.</p>
         </div>
         <button class="expand-btn" onclick="toggleCode(this)">Show Code</button>
-        <div class="code-block">
+        <div class="code-wrapper" style="position:relative;">
+          <pre class="code-block">
 &lt;div style="display:block; background:#03a9f4; color:white; padding:10px;"&gt;Block Element 1&lt;/div&gt;
 &lt;div style="display:block; background:#4caf50; color:white; padding:10px;"&gt;Block Element 2&lt;/div&gt;
 &lt;p&gt;Block elements take full width and start on a new line.&lt;/p&gt;
+          </pre>
         </div>
       </div>
 
@@ -59,15 +61,16 @@
         <h3>Display: Inline-Block</h3>
         <div class="demo-preview">
           <div style="display:inline-block; background:#fcd5ce; color:#333; padding:10px; margin-right:10px; border-radius:6px;">Inline-Block 1</div>
-<div style="display:inline-block; background:#e0bbf6; color:#333; padding:10px; border-radius:6px;">Inline-Block 2</div>
-<p style="opacity:0.7;">Inline-block allows setting width/height while keeping elements on same line.</p>
-
+          <div style="display:inline-block; background:#e0bbf6; color:#333; padding:10px; border-radius:6px;">Inline-Block 2</div>
+          <p style="opacity:0.7;">Inline-block allows setting width/height while keeping elements on same line.</p>
         </div>
         <button class="expand-btn" onclick="toggleCode(this)">Show Code</button>
-        <div class="code-block">
+        <div class="code-wrapper" style="position:relative;">
+          <pre class="code-block">
 &lt;div style="display:inline-block; background:#e91e63; color:white; padding:10px;"&gt;Inline-Block 1&lt;/div&gt;
 &lt;div style="display:inline-block; background:#9c27b0; color:white; padding:10px;"&gt;Inline-Block 2&lt;/div&gt;
 &lt;p&gt;Inline-block allows setting width/height while keeping elements on same line.&lt;/p&gt;
+          </pre>
         </div>
       </div>
 
@@ -76,10 +79,54 @@
 
   <script>
     function toggleCode(button) {
-      const code = button.nextElementSibling;
-      const isVisible = code.style.display === "block";
-      code.style.display = isVisible ? "none" : "block";
+      let wrapper = button.nextElementSibling;
+      let codeBlock;
+      // Always expect wrapper to be .code-wrapper, else wrap it
+      if (wrapper.classList && wrapper.classList.contains('code-wrapper')) {
+        codeBlock = wrapper.querySelector('.code-block');
+      } else if (wrapper.classList && wrapper.classList.contains('code-block')) {
+        codeBlock = wrapper;
+        // If not wrapped, wrap it now
+        const newWrapper = document.createElement('div');
+        newWrapper.className = 'code-wrapper';
+        newWrapper.style.position = 'relative';
+        wrapper.parentNode.insertBefore(newWrapper, wrapper);
+        newWrapper.appendChild(wrapper);
+        wrapper = newWrapper;
+      } else {
+        return;
+      }
+      const isVisible = codeBlock.style.display === "block";
+      codeBlock.style.display = isVisible ? "none" : "block";
       button.textContent = isVisible ? "Show Code" : "Hide Code";
+
+      // Add/remove copy button
+      if (!isVisible) {
+        if (!wrapper.querySelector('.copy-btn')) {
+          const copyBtn = document.createElement('button');
+          copyBtn.className = 'copy-btn';
+          copyBtn.textContent = 'Copy';
+          copyBtn.type = 'button';
+          copyBtn.onclick = function(e) {
+            e.stopPropagation();
+            copyCode(codeBlock, copyBtn);
+          };
+          wrapper.appendChild(copyBtn);
+        }
+      } else {
+        const btn = wrapper.querySelector('.copy-btn');
+        if (btn) btn.remove();
+      }
+    }
+
+    function copyCode(codeBlock, btn) {
+      btn.style.display = 'none';
+      const code = codeBlock.innerText;
+      btn.style.display = '';
+      navigator.clipboard.writeText(code).then(() => {
+        btn.textContent = 'Copied!';
+        setTimeout(() => { btn.textContent = 'Copy'; }, 1200);
+      });
     }
 
     const themeToggleBtn = document.getElementById('theme-toggle');
@@ -253,6 +300,26 @@
       margin-top: 10px;
       white-space: pre-wrap;
       overflow-x: auto;
+      position: relative; /* For copy button positioning */
+    }
+    .copy-btn {
+      position: absolute;
+      top: 12px;
+      right: 16px;
+      background: #444;
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      padding: 5px 12px;
+      font-size: 0.9em;
+      cursor: pointer;
+      z-index: 2;
+      opacity: 0.85;
+      transition: background 0.2s, opacity 0.2s;
+    }
+    .copy-btn:hover {
+      background: #007bff;
+      opacity: 1;
     }
   </style>
 </body>

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -156,6 +156,26 @@
       margin-top: 10px;
       white-space: pre-wrap;
       overflow-x: auto;
+      position: relative; /* For copy button positioning */
+    }
+    .copy-btn {
+      position: absolute;
+      top: 12px;
+      right: 16px;
+      background: #444;
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      padding: 5px 12px;
+      font-size: 0.9em;
+      cursor: pointer;
+      z-index: 2;
+      opacity: 0.85;
+      transition: background 0.2s, opacity 0.2s;
+    }
+    .copy-btn:hover {
+      background: #007bff;
+      opacity: 1;
     }
     .hamburger-btn {
       display: block;
@@ -212,9 +232,11 @@
           </div>
         </div>
         <button class="expand-btn" onclick="toggleCode(this)">Show Code</button>
-        <div class="code-block">
+        <div class="code-wrapper" style="position:relative;">
+          <pre class="code-block">
 &lt;div style="position:sticky; top:0; background:#007BFF; color:white; padding:8px 10px;"&gt;I'm stuck to the top!&lt;/div&gt;
 &lt;div style="height:400px;"&gt;...&lt;/div&gt;
+          </pre>
         </div>
       </div>
 
@@ -229,7 +251,8 @@
           </div>
         </div>
         <button class="expand-btn" onclick="toggleCode(this)">Show Code</button>
-        <div class="code-block">
+        <div class="code-wrapper" style="position:relative;">
+          <pre class="code-block">
 &lt;div class="hamburger-btn" onclick="toggleHamburger(this)"&gt;☰&lt;/div&gt;
 &lt;div class="demo-nav-links"&gt;
   &lt;a href="#"&gt;Link One&lt;/a&gt;
@@ -241,6 +264,7 @@
 .hamburger-btn { cursor: pointer; }
 .demo-nav-links { display: none; }
 &lt;/style&gt;
+          </pre>
         </div>
       </div>
 
@@ -249,10 +273,54 @@
 
   <script>
     function toggleCode(button) {
-      const code = button.nextElementSibling;
-      const isVisible = code.style.display === "block";
-      code.style.display = isVisible ? "none" : "block";
+      // Always expect wrapper to be .code-wrapper, else wrap it
+      let wrapper = button.nextElementSibling;
+      let codeBlock;
+      if (wrapper.classList && wrapper.classList.contains('code-wrapper')) {
+        codeBlock = wrapper.querySelector('.code-block');
+      } else if (wrapper.classList && wrapper.classList.contains('code-block')) {
+        codeBlock = wrapper;
+        // If not wrapped, wrap it now
+        const newWrapper = document.createElement('div');
+        newWrapper.className = 'code-wrapper';
+        newWrapper.style.position = 'relative';
+        wrapper.parentNode.insertBefore(newWrapper, wrapper);
+        newWrapper.appendChild(wrapper);
+        wrapper = newWrapper;
+      } else {
+        return;
+      }
+      const isVisible = codeBlock.style.display === "block";
+      codeBlock.style.display = isVisible ? "none" : "block";
       button.textContent = isVisible ? "Show Code" : "Hide Code";
+
+      // Add/remove copy button
+      if (!isVisible) {
+        if (!wrapper.querySelector('.copy-btn')) {
+          const copyBtn = document.createElement('button');
+          copyBtn.className = 'copy-btn';
+          copyBtn.textContent = 'Copy';
+          copyBtn.type = 'button';
+          copyBtn.onclick = function(e) {
+            e.stopPropagation();
+            copyCode(codeBlock, copyBtn);
+          };
+          wrapper.appendChild(copyBtn);
+        }
+      } else {
+        const btn = wrapper.querySelector('.copy-btn');
+        if (btn) btn.remove();
+      }
+    }
+
+    function copyCode(codeBlock, btn) {
+      btn.style.display = 'none';
+      const code = codeBlock.innerText;
+      btn.style.display = '';
+      navigator.clipboard.writeText(code).then(() => {
+        btn.textContent = 'Copied!';
+        setTimeout(() => { btn.textContent = 'Copy'; }, 1200);
+      });
     }
 
     function toggleHamburger(btn) {

--- a/templates/neumorphic.html
+++ b/templates/neumorphic.html
@@ -130,6 +130,27 @@
       font-size: 0.9rem;
       border-radius: 8px;
       overflow-x: auto;
+      position: relative; /* For copy button positioning */
+    }
+
+    .copy-btn {
+      position: absolute;
+      top: 12px;
+      right: 16px;
+      background: #444;
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      padding: 5px 12px;
+      font-size: 0.9em;
+      cursor: pointer;
+      z-index: 2;
+      opacity: 0.85;
+      transition: background 0.2s, opacity 0.2s;
+    }
+    .copy-btn:hover {
+      background: #007bff;
+      opacity: 1;
     }
 
     .toggle-btn {
@@ -298,7 +319,49 @@ body {
   <script>
     function toggleCode(level) {
       const block = document.getElementById("code" + level);
-      block.style.display = block.style.display === "block" ? "none" : "block";
+      // Ensure the code block is wrapped for absolute positioning of the copy button
+      let wrapper = block.parentElement;
+      if (!wrapper.classList.contains('code-wrapper')) {
+        const newWrapper = document.createElement('div');
+        newWrapper.className = 'code-wrapper';
+        newWrapper.style.position = 'relative';
+        block.parentNode.insertBefore(newWrapper, block);
+        newWrapper.appendChild(block);
+        wrapper = newWrapper;
+      }
+      const isVisible = block.style.display === "block";
+      block.style.display = isVisible ? "none" : "block";
+
+      // Add/remove copy button (does not affect Show button UI)
+      if (!isVisible) {
+        if (!wrapper.querySelector('.copy-btn')) {
+          const copyBtn = document.createElement('button');
+          copyBtn.className = 'copy-btn';
+          copyBtn.textContent = 'Copy';
+          copyBtn.type = 'button';
+          copyBtn.style.position = 'absolute';
+          copyBtn.style.top = '12px';
+          copyBtn.style.right = '16px';
+          copyBtn.onclick = function(e) {
+            e.stopPropagation();
+            copyCode(block, copyBtn);
+          };
+          wrapper.appendChild(copyBtn);
+        }
+      } else {
+        const btn = wrapper.querySelector('.copy-btn');
+        if (btn) btn.remove();
+      }
+    }
+
+    function copyCode(codeBlock, btn) {
+      btn.style.display = 'none';
+      const code = codeBlock.innerText;
+      btn.style.display = '';
+      navigator.clipboard.writeText(code).then(() => {
+        btn.textContent = 'Copied!';
+        setTimeout(() => { btn.textContent = 'Copy'; }, 1200);
+      });
     }
   </script>
 </body>

--- a/templates/social-share-buttons.html
+++ b/templates/social-share-buttons.html
@@ -351,6 +351,28 @@
       text-align: left;
       font-family: "Fira Code", "Courier New", monospace;
       font-size: 0.85rem;
+      position: relative; /* For copy button positioning */
+    }
+
+    .copy-btn {
+      position: absolute;
+      top: 12px;
+      right: 16px;
+      background: #444;
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      padding: 5px 12px;
+      font-size: 0.9em;
+      cursor: pointer;
+      z-index: 2;
+      opacity: 0.85;
+      transition: background 0.2s, opacity 0.2s;
+    }
+
+    .copy-btn:hover {
+      background: #007bff;
+      opacity: 1;
     }
 
     @media (max-width: 768px) {
@@ -406,11 +428,13 @@
           class="tooltip">Instagram</span></a>
     </div>
     <button class="expand-btn" onclick="toggleCode(this)">Show Code</button>
-    <pre class="code-block">&lt;!-- HTML --&gt;
+    <div class="code-wrapper" style="position:relative;">
+      <pre class="code-block">&lt;!-- HTML --&gt;
 &lt;a href="#" class="social-btn v1" style="--original-color:#3b5998;"&gt;
   &lt;i class="fab fa-facebook-f"&gt;&lt;/i&gt;
   &lt;span class="tooltip"&gt;Facebook&lt;/span&gt;
 &lt;/a&gt;</pre>
+    </div>
   </section>
 
   <section>
@@ -500,10 +524,52 @@
 
   <script>
     function toggleCode(button) {
-      const codeBlock = button.nextElementSibling;
+      let wrapper = button.nextElementSibling;
+      let codeBlock;
+      if (wrapper.classList && wrapper.classList.contains('code-wrapper')) {
+        codeBlock = wrapper.querySelector('.code-block');
+      } else if (wrapper.classList && wrapper.classList.contains('code-block')) {
+        codeBlock = wrapper;
+        // If not wrapped, wrap it now
+        const newWrapper = document.createElement('div');
+        newWrapper.className = 'code-wrapper';
+        newWrapper.style.position = 'relative';
+        wrapper.parentNode.insertBefore(newWrapper, wrapper);
+        newWrapper.appendChild(wrapper);
+        wrapper = newWrapper;
+      } else {
+        return;
+      }
       const isVisible = codeBlock.style.display === "block";
       codeBlock.style.display = isVisible ? "none" : "block";
       button.textContent = isVisible ? "Show Code" : "Hide Code";
+
+      if (!isVisible) {
+        if (!wrapper.querySelector('.copy-btn')) {
+          const copyBtn = document.createElement('button');
+          copyBtn.className = 'copy-btn';
+          copyBtn.textContent = 'Copy';
+          copyBtn.type = 'button';
+          copyBtn.onclick = function(e) {
+            e.stopPropagation();
+            copyCode(codeBlock, copyBtn);
+          };
+          wrapper.appendChild(copyBtn);
+        }
+      } else {
+        const btn = wrapper.querySelector('.copy-btn');
+        if (btn) btn.remove();
+      }
+    }
+
+    function copyCode(codeBlock, btn) {
+      btn.style.display = 'none';
+      const code = codeBlock.innerText;
+      btn.style.display = '';
+      navigator.clipboard.writeText(code).then(() => {
+        btn.textContent = 'Copied!';
+        setTimeout(() => { btn.textContent = 'Copy'; }, 1200);
+      });
     }
 
     const themeToggleBtn = document.getElementById("theme-toggle");
@@ -529,6 +595,6 @@
 
     applyTheme();
   </script>
-</body>
 
-</html>
+
+</body></html>


### PR DESCRIPTION
# 🚀 Pull Request

## 📄 Description
Added a copy to clipboard button for the code blocks in multiple templates.
The copy button becomes visible when the "Show Code" button is clicked, allowing users to easily copy the displayed code
Fixes #331

## 🛠️ Type of Change
- [ ] New feature ✨

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have linked the issue using `Fixes #331`
