### PR TITLE
Fix: Contributor data not showing on contributors page (#434)

### DIFF
--- a/script.js
+++ b/script.js
@@ -83,8 +83,8 @@ window.addEventListener('DOMContentLoaded', () => {
 
   // 📨 Contact form validation
   const contactForm = document.querySelector('.contact-form');
-  const formInputs = contactForm.querySelectorAll('input[required], textarea[required]');
   if (contactForm) {
+    const formInputs = contactForm.querySelectorAll('input[required], textarea[required]');
     function checkFormValidity() {
       return [...formInputs].every(input => input.value.trim() !== '');
     }
@@ -109,30 +109,38 @@ window.addEventListener('DOMContentLoaded', () => {
 
   // 🧑‍💻 Contributors fetch
   const contributorsGrid = document.getElementById('contributors-grid');
-  if (contributorsGrid) {
-    fetch('https://api.github.com/repos/itsAnimation/AnimateItNow/contributors')
-      .then(res => res.json())
-      .then(contributors => {
-        contributorsGrid.innerHTML = '';
-        contributors.forEach(contributor => {
-          const card = document.createElement('a');
-          card.href = contributor.html_url;
-          card.className = 'contributor-card';
-          card.target = '_blank';
-          card.rel = 'noopener noreferrer';
-          card.innerHTML = `
-            <img src="${contributor.avatar_url}" alt="${contributor.login}" class="contributor-avatar">
-            <h3>${contributor.login}</h3>
-            <p>Contributions: ${contributor.contributions}</p>
-          `;
-          contributorsGrid.appendChild(card);
-        });
-      })
-      .catch(err => {
-        console.error('Error fetching contributors:', err);
-        contributorsGrid.innerHTML = '<p>Could not load contributors at this time.</p>';
+if (contributorsGrid) {
+  fetch('https://api.github.com/repos/itsAnimation/AnimateItNow/contributors')
+    .then(res => {
+      if (!res.ok) throw new Error('GitHub API failed');
+      return res.json();
+    })
+    .then(contributors => {
+      if (!contributors.length) {
+        contributorsGrid.innerHTML = '<p>No contributors found.</p>';
+        return;
+      }
+
+      contributorsGrid.innerHTML = '';
+      contributors.forEach(contributor => {
+        const card = document.createElement('a');
+        card.href = contributor.html_url;
+        card.className = 'contributor-card';
+        card.target = '_blank';
+        card.rel = 'noopener noreferrer';
+        card.innerHTML = `
+          <img src="${contributor.avatar_url}" alt="${contributor.login}" class="contributor-avatar">
+          <h3>${contributor.login}</h3>
+          <p>Contributions: ${contributor.contributions}</p>
+        `;
+        contributorsGrid.appendChild(card);
       });
-  }
+    })
+    .catch(err => {
+      console.error('Error fetching contributors:', err);
+      contributorsGrid.innerHTML = '<p>Could not load contributors at this time.</p>';
+    });
+}
   
 const isMobile = window.matchMedia('(max-width: 768px)').matches;
 const cursorToggle = document.getElementById('cursorToggle');


### PR DESCRIPTION
# 🚀 Pull Request

## 📄 Description

Fixes #434

The Contributors section on the contributors.html page was not displaying any GitHub contributor cards. This happened because a `querySelectorAll` was being called on a `null` element (`contactForm`) before checking its existence, which crashed the entire script execution.

### 🔍 Root Cause
- The DOM query for `.contact-form` ran even when that form wasn't on the page.
- This broke the script and prevented the contributors section from rendering.

### ✅ Solution
- Moved the `formInputs` selector inside the `if (contactForm)` block.
- Now the script runs only if the contact form is present.
- As a result, the contributor cards are successfully fetched and displayed using the GitHub API.

---

## 🛠️ Type of Change

- [x] Bug fix 🐛
- [ ] New feature ✨
- [ ] Code refactor🛠️
- [ ] Documentation update 📝
- [ ] Other (please describe):

---

## ✅ Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have added tests that prove my fix is effective or that my feature works  
- [x] I have linked the issue using `Fixes #434`  

---

## 🖼️ Screenshots (if available)

Here is the updated contributors section now rendering correctly:
<img width="1441" height="816" alt="animateitnow" src="https://github.com/user-attachments/assets/e7d85e40-357b-4c7c-9a4a-36ac67a8b16e" />
---

## 🔗 Related Issues

N/A

---

## 🧠 Additional Context

Contributed as part of GSSoC’25 by @Varnika060306 🚀  
Let me know if any further changes are needed. Happy to improve this further!
