### PR TITLE
about and templates make active on clicking and dark mode icon visible

### DIFF
--- a/about.html
+++ b/about.html
@@ -46,8 +46,10 @@
 
     <div class="nav-right">
       <ul class="nav-links">
-        <li><a href="index.html" class="active">Home</a></li>
-        <li><a href="about.html">About</a></li>
+        <!-- remove active from Home -->
+        <li><a href="index.html">Home</a></li>
+        <!-- make active to About as you are in about -->
+        <li><a href="about.html" class="active">About</a></li>
         <li><a href="templates.html">Templates</a></li>
         <li><a href="contributors.html">Contributors</a></li>
         <li><a href="contact.html">Contact</a></li>

--- a/templates.html
+++ b/templates.html
@@ -330,9 +330,10 @@
     </div>
     <div class="nav-right">
       <ul class="nav-links">
-        <li><a href="index.html" class="active">Home</a></li>
+        <li><a href="index.html">Home</a></li>
         <li><a href="about.html">About</a></li>
-        <li><a href="templates.html">Templates</a></li>
+        <!-- template class must be active when we click on it -->
+        <li><a href="templates.html" class="active">Templates</a></li>
         <li><a href="contributors.html">Contributors</a></li>
         <li><a href="contact.html">Contact</a></li>
         <li><a href="leaderboard.html">Leaderboard</a></li>


### PR DESCRIPTION
# 🚀 Pull Request

## 📄 Description 
Fixes #515 

## 🛠️ Type of Change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix 🐛 --> fixes the bug that when click on about and template , home nav is still focus so , I fix it 
                         --> and dark theme logo in about is already fixes
- [ ] New feature ✨ 

## ✅ Checklist
- [✅] My code follows the style guidelines of this project
- [✅] I have performed a self-review of my code
- [✅] I have commented my code, particularly in hard-to-understand areas
- [✅] I have added tests that prove my fix is effective or that my feature works
- [✅] I have linked the issue using `Fixes #515`

## 📸 Screenshots 
<img width="1039" height="428" alt="image" src="https://github.com/user-attachments/assets/a4f52fdf-5d0b-4334-b2b0-49443abf2c0d" />


