### PR TITLE
Fix: FAQ section visibility, formatting, and dark mode text issue

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2212,6 +2212,11 @@ body.dark .template-card h2 {
   color: var(--primary-text);
   font-size: 1.2rem;
 }
+body.dark .faq-section {
+  background-color: rgba(30, 30, 30, 0.6); /* darker translucent background for dark mode */
+  border: 1px solid rgba(255, 255, 255, 0.1); /* optional: slightly dimmer border */
+}
+
 
 /* moving neon-style glow */
 .glow-wrap {


### PR DESCRIPTION
# 🚀 Pull Request

## 📄 Description
Fixed FAQ section formatting and visibility issues. Ensured answers are hidden by default and only shown when the corresponding question is clicked. Also fixed text visibility in dark mode.
Fixes #624 

## 🛠️ Type of Change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix 🐛

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have linked the issue using `Fixes #issue_number`

## 📸 Screenshots (if available)
before:

[screen-capture (3).webm](https://github.com/user-attachments/assets/9e0e1aba-3586-45e1-8691-ec85dba6d8fa)

after (now):
<img width="1888" height="975" alt="Screenshot 2025-07-29 185041" src="https://github.com/user-attachments/assets/a8143a18-7106-4ebe-87d4-28f915d5e2c6" />


## 🧠 Additional Context
The FAQ section previously displayed both questions and answers at once without interactivity. This update restores expected accordion behavior and ensures readability in both light and dark themes
