### PR TITLE
Fix: Improve Visibility of 'Templates Gallery' and 'Get in Touch' Headings 

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1075,7 +1075,8 @@ body.dark .landing-section p {
   letter-spacing: 1px;
   animation: fadeIn 1s ease-in-out;
 background: linear-gradient(to right, #34d399, #3b82f6);
-
+background-clip: text;
+-webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   text-shadow: 0 0 5px rgba(59, 130, 246, 0.15);
 }
@@ -1506,8 +1507,8 @@ body.dark .contributor-card:hover {
   font-weight: 800;
   text-align: center;
   background: linear-gradient(to right, red,blue);
-  color: transparent;
-
+ -webkit-background-clip: text;
+ -webkit-text-fill-color: transparent;
   text-shadow: 0 2px 4px rgba(0, 0, 0, 0.15),
                0 4px 8px rgba(79, 140, 255, 0.25);
   margin-bottom: 1.5rem;
@@ -1643,14 +1644,13 @@ body.dark .nav-links a {
 
 body.dark .contact-main h1 {
   /* color: #8aadf4; */
-  background: linear-gradient(to right, rgb(80, 12, 80),rgb(143, 220, 160));
-  color: transparent;
-  /* -webkit-background-clip: text; */
+  background: linear-gradient(to right, #67e8f9, #3b82f6);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
   text-shadow:
   0 0 4px rgba(138, 180, 248, 0.4),  
   0 0 10px rgba(138, 180, 248, 0.2),  
   0 0 20px rgba(138, 180, 248, 0.1);  
-
 }
 
 body.dark .animated-btn-section h1 {

--- a/templates.html
+++ b/templates.html
@@ -66,7 +66,8 @@
     /* ✅ Heading fix */
     body.dark .templates-main h1 {
        background: linear-gradient(to right, #67e8f9, #3b82f6); /* bright neon cyan-blue */
-       /* -webkit-background-clip: text; */
+       -webkit-background-clip:text;
+       background-clip: text;
        -webkit-text-fill-color: transparent;
         text-shadow: 0 2px 10px rgba(56, 189, 248, 0.4);
     }


### PR DESCRIPTION
# 🚀 Pull Request

## 📄 Description
Fixes #635

Improved the visibility of the "Templates Gallery" and "Get in Touch" headings which were earlier blending into the gradient background. Applied a high-contrast blue gradient with subtle text-shadow for better readability and visual appeal.

## 🛠️ Type of Change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix 🐛
- [ ] New feature ✨
- [ ] Code refactor 🔨
- [ ] Documentation update 📚
- [ ] Other (please describe):

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have linked the issue using `Fixes #635`

## 📸 Screenshots -
<img width="1906" height="404" alt="image" src="https://github.com/user-attachments/assets/5ce424e3-4731-4ea8-b782-acab788a407a" />
<img width="1906" height="438" alt="image" src="https://github.com/user-attachments/assets/207c2c1c-f81f-483b-83af-be31935bdccd" />


## 📚 Related Issues
None

## 🧠 Additional Context
This update enhances accessibility and overall design clarity for headings placed on gradient backgrounds.


