### PR TITLE
Fix: Updated email link to open Gmail directly

### DIFF
--- a/index.html
+++ b/index.html
@@ -384,7 +384,13 @@
           <li class="github"><a href="https://github.com/itsAnimation/AnimateItNow" target="_blank"><i class="fab fa-github fa-beat"></i> GitHub</a></li>
           <li><a href="https://www.linkedin.com/in/anujshrivastava1/" target="_blank"><i class="fab fa-linkedin fa-beat"></i> LinkedIn</a></li> 
           <!-- fa-beat class added in email for animation -->
-          <li><a href="mailto:contact@animateitnow.com"><i class="fas fa-envelope fa-beat"></i> Email Us</a></li> 
+          <li>
+  <a href="https://mail.google.com/mail/?view=cm&to=contact@animateitnow.com" target="_blank">
+    <i class="fas fa-envelope fa-beat"></i> Email Us
+  </a>
+</li>
+
+
         </ul>
       </div>
     </div>


### PR DESCRIPTION
# 🚀 Pull Request

## 📄 Description
Fixed the  Email Us issue of not directing to mail in the Footer Section  
Fixes #612 

## 🛠️ Type of Change
- [x] Documentation update 📚

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have linked the issue using `Fixes #issue_number`

## 📸 Screenshots (if available)
 🥲Earlier with issue

https://github.com/user-attachments/assets/90248d60-ff72-419a-b925-2cd2eaa48f93

😊After Solving the issue

https://github.com/user-attachments/assets/3ac1420c-2d2b-487d-8ca9-44483f32984e


