### PR TITLE
Created a message and styling for no templates found.

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -69,7 +69,18 @@
 body.dark .ripple::before {
   background: var(--ripple-color-dark);
 }
+.no-results {
+  display: none;
+  text-align: center;
+  color: #111;         /* Black for light mode */
+  font-weight: bold;
+  margin-bottom: 1.5rem;
+}
 
+body.dark-theme .no-results,
+body.dark .no-results {
+  color: #fff;         /* White for dark mode */
+}
 /* Enhanced button press feedback */
 .btn-press {
   transition: transform 0.1s ease, box-shadow 0.1s ease;

--- a/templates.html
+++ b/templates.html
@@ -419,6 +419,9 @@
           aria-label="Search templates"
         />
       </div>
+       <div class="no-results">
+  No Templates Found.
+</div>
       <section class="templates-grid">
         <a class="template-card" href="templates/LoginFormGlassMorphism.html">
           <h2>Login Form with Glassmorphism.</h2>
@@ -662,7 +665,7 @@
       // Search & Category Filter Functionality
       const searchBar = document.getElementById("search-bar");
       const templateCards = document.querySelectorAll(".template-card");
-      // const noResultsMsg = document.getElementById('no-results'); // Optional: Add a "no results" div to your HTML
+      const noResultsMsg = document.querySelector(".no-results"); // Added a "no results" div to your HTML
 
       function filterTemplates() {
         const query = searchBar.value.trim().toLowerCase();
@@ -681,11 +684,11 @@
             card.style.display = "none";
           }
         });
-        /*
+        
       if (noResultsMsg) {
           noResultsMsg.style.display = visibleCount === 0 ? 'block' : 'none';
       }
-      */
+      
       }
 
       searchBar.addEventListener("input", filterTemplates);


### PR DESCRIPTION
# 🚀 Pull Request

## 📄 Description
This PR adds a user-friendly message and corresponding styling to handle cases where no templates are found in the search results. 

## ✅ What’s Included

- 🔍 **Empty State Logic**  
  Conditional rendering in `templates.html` to check if search results are empty.

- 🖼️ **User Message Display**  
  Shows the text **"No templates found."** in a user-friendly format.

- 🎨 **Styling**  
  CSS added in `styles.css` to style the message consistently with the app's UI.

---

## 🧪 How to Test

1. Navigate to the **templates** or **search** page.
2. Enter a keyword that does **not match any templates**.
3. You should see the following message styled on screen:

   > **No templates found.**

---

## 📂 Files Modified

- `templates.html`  
  - Added conditional logic for empty search state  
  - Added markup to display message

- `styles.css`  
  - Added `.no-results` class for styling the message

---
## 📸 Screenshots (if available)
<img width="1919" height="867" alt="image" src="https://github.com/user-attachments/assets/1fd766b3-7a7c-438f-a78d-056e02ed6688" />
<img width="1904" height="870" alt="image" src="https://github.com/user-attachments/assets/9359aa14-6b92-44fb-8a75-a4f565a44616" />



## 📚 Related Issues
 Issue : #658 

## 🧠 Additional Context
- Let me know if you'd like the message text or styling to be adjusted.
- Happy to make changes based on feedback.
