### PR TITLE
🔧 Fix: Resolved FAQ Card Overlap Issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -309,39 +309,37 @@
                                 the design — colors, layouts, animations, responsiveness, and overall look and feel. It
                                 allows developers to create visually appealing and user-friendly websites that work well
                                 across different devices and screen sizes.</p>
-
-                            <!-- 03-->
-                            <div class="faq-item glow-wrap">
-                                <div class="faq-question-header" onclick="toggleFAQ(this)">
-                                    <h3>What is Javascript?</h3>
-                                    <div class="faq-icon-static"><i class="fas fa-microchip"></i></div>
-                                </div>
-                                <div class="faq-answer-content">
-                                    <p>JavaScript is the programming language of the web. It adds interactivity and
+                        </div>
+                    </div>
+                    <!-- 03-->
+                    <div class="faq-item glow-wrap">
+                        <div class="faq-question-header" onclick="toggleFAQ(this)">
+                            <h3>What is Javascript?</h3>
+                            <div class="faq-icon-static"><i class="fas fa-microchip"></i></div>
+                        </div>
+                        <div class="faq-answer-content">
+                           <p>JavaScript is the programming language of the web. It adds interactivity and
                                         dynamic behavior to your web pages like sliders, buttons that respond to clicks,
                                         form validation, animations, and real-time updates. Without JavaScript, a
                                         website would be static and unresponsive. It's essential for building modern,
                                         interactive user experiences..</p>
-                                </div>
-                            </div>
+                        </div>
+                    </div>
 
-                            <!-- 04-->
-                            <div class="faq-item glow-wrap">
-                                <div class="faq-question-header" onclick="toggleFAQ(this)">
-                                    <h3>How do I preview my changes locally?</h3>
-                                    <div class="faq-icon-static">
-                                        <i class="fas fa-desktop"></i>
-                                    </div>
-                                </div>
-                                <div class="faq-answer-content">
-                                    <p>
+                    <!-- 04-->
+                      <div class="faq-item glow-wrap">
+                          <div class="faq-question-header" onclick="toggleFAQ(this)">
+                              <h3>How do I preview my changes locally?</h3>
+                                  <div class="faq-icon-static">
+                                    <i class="fas fa-desktop"></i>
+                          </div>
+                              </div>
+                            <div class="faq-answer-content">
+                                <p>
                                         Open index.html in a browser or use VS Code's Live Server
                                         extension for live preview.
-                                    </p>
-                                </div>
-                            </div>
+                                </p>
                         </div>
-
                     </div>
                 </div><!-- /faq-container-->
         </section>


### PR DESCRIPTION
## 🔧 Fix: Resolved FAQ Card Overlap Issue

- Fixed a layout bug in the FAQ section where one question card was overlapping or nested inside another.
- Ensured each FAQ item is displayed within its own distinct, properly spaced card.
- Reviewed and corrected any misused or missing HTML tags and verified flex/grid structure.
- Improved overall visual structure and readability.

Closes #733 @AnujShrivastava01 
<img width="1664" height="863" alt="image" src="https://github.com/user-attachments/assets/23be01ee-1718-47af-b3ad-7187c6607a03" />
