### PR TITLE
fix: improve contrast in leaderboard section for better dark mode visibility

### DIFF
--- a/leaderboard.html
+++ b/leaderboard.html
@@ -43,8 +43,8 @@
   /*Dark mode for glass heading */
   .dark .glass-heading {
     color: #ffffff;
-    background: rgba(255,255,255,0.1);
-    border: 1.5px solid rgba(255,255,255,0.1);
+    background: rgba(0, 0, 0, 0.458);
+    border: 1.5px solid rgba(31, 164, 182, 0.334);
     box-shadow: 0 8px 32px 0 rgba(0,0,0,0.3);
   }
   /*Search container with transparent background */
@@ -78,12 +78,12 @@
   }
   /*Dark mode for search input */
   .dark .search-input {
-    background: #2d2d2d;
+    background: #00000093;
     color: #ffffff;
-    border-color: #404040;
+    border-color: #ffffff5f;
   }
   .dark .search-input:focus {
-    border-color: #4dabf7;
+    border-color: #55cad0;
     box-shadow: 0 4px 20px rgba(77,171,247,0.3);
   }
   /*Search button styling */
@@ -119,8 +119,9 @@
   }
   /*Dark mode for table container */
   .dark .table-container {
-    background: #2d2d2d;
-    box-shadow: 0 10px 30px rgba(0,0,0,0.4);
+    background: #000000;
+    border: 2px solid rgb(28, 145, 135);
+    box-shadow: 0 10px 30px rgba(36, 163, 158, 0.432);
   }
   /*Table styling */
   .leaderboard-table {
@@ -142,10 +143,21 @@
   /*Dark mode for table cells */
   .dark .leaderboard-table th,
   .dark .leaderboard-table td {
-    border-bottom: 1px solid #404040;
+    border-bottom: 1px solid #159d8897;
   }
   .leaderboard-table th {
     background: linear-gradient(135deg, #1e1e2f 0%, #2d2d4a 100%);
+    color: #ffffff;
+    font-weight: 700;
+    font-size: 1.1rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+  }
+  .dark .leaderboard-table th {
+    background: linear-gradient(135deg, #0a312e 0%, #3b817f 100%);
     color: #ffffff;
     font-weight: 700;
     font-size: 1.1rem;
@@ -189,9 +201,16 @@
     font-weight: 600;
     color: #28a745;
   }
+  .dark .leaderboard-table th:last-child,
+  .dark .leaderboard-table td:last-child {
+    width: 120px;
+    text-align: center;
+    font-weight: 600;
+    color: #ffffff;
+  }
   /*Dark mode for points column */
   .dark .leaderboard-table td:last-child {
-    color: #51cf66;
+    color: #29ddcb;
   }
   /*Avatar styling */
   .contributor-avatar {
@@ -231,10 +250,10 @@
   }
   /*Dark mode for contributor links */
   .dark .contributor-link {
-    color: #4dabf7;
+    color: #43c3b6e2;
   }
   .dark .contributor-link:hover {
-    color: #74c0fc;
+    color: #156d6d;
   }
   /*PR Details styling */
   .pr-details {
@@ -304,7 +323,7 @@
   }
   .pagination-btn {
     padding: 12px 20px;
-    background: linear-gradient(135deg, #007bff 0%, #0056b3 100%);
+    background: linear-gradient(135deg, #00fff7 0%, #041322 100%);
     color: white;
     border: none;
     border-radius: 8px;


### PR DESCRIPTION
# 🚀 Pull Request

## 📄 Description
Improved the visual contrast of the Leaderboard section in Dark Mode to enhance readability and UI clarity. Updated background and text colors to align with the overall theme while ensuring sufficient contrast.

Fixes #789 

## 🛠️ Type of Change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix 🐛
- [ ] New feature ✨
- [ ] Code refactor 🔨
- [ ] Documentation update 📚
- [x] Other (please describe)

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have linked the issue using `Fixes #789 `

## 📸 Screenshots (if available)
Before--
<img width="707" height="966" alt="image" src="https://github.com/user-attachments/assets/076b4c76-8b94-47ab-9179-86263c73b682" />

After--
<img width="1858" height="1023" alt="image" src="https://github.com/user-attachments/assets/b0295a7c-eca1-46b8-928f-4b68c63ccda4" />
<img width="656" height="965" alt="image" src="https://github.com/user-attachments/assets/95452df6-afd5-46b5-8fa9-caf3726e47c4" />
<img width="1766" height="633" alt="image" src="https://github.com/user-attachments/assets/4bb98327-bb7f-4af4-a0cd-32daf253fd13" />


## 📚 Related Issues
None

## 🧠 Additional Context
The changes were made to maintain visual consistency in dark mode and improve accessibility for users with visual strain. Let me know if you’d like any further adjustments!
