### PR TITLE
Fix: Added missing hover effect to navbar on Templates and Leaderboard pages

### DIFF
--- a/leaderboard.html
+++ b/leaderboard.html
@@ -533,6 +533,7 @@
       <li><a href="about.html">About</a></li>
       <li><a href="editor.html" target="_blank">Editor</a></li>
       <li><a href="templates.html">Templates</a></li>
+      <li><a href="playground.html" style="white-space: nowrap">Hover-Effects</a></li>
       <li><a href="contributors.html">Contributors</a></li>
       <li><a href="contact.html">Contact</a></li>
       <li><a href="leaderboard.html" class="active">Leaderboard</a></li>

--- a/templates.html
+++ b/templates.html
@@ -549,6 +549,7 @@
           <li><a href="about.html">About</a></li>
           <li><a href="editor.html" target="_blank">Editor</a></li>
           <li><a href="templates.html" class="active">Templates</a></li>
+          <li><a href="playground.html" style="white-space: nowrap">Hover-Effects</a></li>
           <li><a href="contributors.html">Contributors</a></li>
           <li><a href="contact.html">Contact</a></li>
           <li><a href="leaderboard.html">Leaderboard</a></li>


### PR DESCRIPTION
### ## 📄 Description
This PR fixes a **bug** where the "Hover-Effects" link was missing from the main navigation bar on the `/templates` and `/leaderboard` pages. The link has been added to ensure the navbar is **consistent** across the entire website. ✨

Fixes #805 
 ---
### ## 🛠️ Type of Change
- [x] Bug fix 🐛


---
### ## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have linked the issue using `Fixes #805 `

---
### ## 📸 Screenshots 
before:
<img width="1913" height="866" alt="Screenshot 2025-08-03 215820" src="https://github.com/user-attachments/assets/c8e47b6d-dae7-4407-8c3a-4fa86392340e" />
<img width="1919" height="873" alt="Screenshot 2025-08-03 215837" src="https://github.com/user-attachments/assets/2650fd41-c3b5-43fe-8a38-2e4ec5c56cc7" />

After :
<img width="1919" height="865" alt="image" src="https://github.com/user-attachments/assets/41c19f31-8231-4388-abfb-f7b131c57b93" />
<img width="1919" height="867" alt="image" src="https://github.com/user-attachments/assets/7b6a38b4-2f57-4add-9ce5-547ae039228a" />

---
### ## 🧠 Additional Context
This change improves the overall user experience by ensuring navigational consistency.