### PR TITLE
[FIX]: #801 Logo Typing Animation Causes Layout Shift in Navbar 

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -286,7 +286,8 @@ body {
   width: 25ch;
   position: relative;
   gap: 12px;
-  color:#00d1ff
+  color:#00d1ff;
+  min-width: 240px;
 }
 
 .logo {


### PR DESCRIPTION
# 🚀 Pull Request

## 📄 Description
Fixes #801  

This PR resolves the **logo text animation glitch** where the typing effect on the site name caused other navbar elements to shift repeatedly.  
The fix applies a `min-width` to the left navbar section (`.nav-left`), ensuring the space for the animated logo text remains constant throughout the typing cycle.  
This prevents layout reflows and keeps the rest of the navigation bar stable while the animation runs.

## 🛠️ Type of Change
- [x] Bug fix 🐛

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have linked the issue using `Fixes #801`

## 📸 Screenshots (if available)
**Before:**  
Navbar elements shift left/right with each typing loop.  
*Already added to the issue description*


**After:**  

https://github.com/user-attachments/assets/5528e033-3a58-495d-93ba-a5037f519149


## 📚 Related Issues
- Closes #801

## 🧠 Additional Context
- Solution: Set `min-width` on `.nav-left` to reserve space for the logo text.  
- Maintains responsive behavior across breakpoints.  
- Typing animation duration & steps remain unchanged for consistent UX.
