### PR TITLE
 Remove Extra "Get Started" Button

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,13 +105,8 @@
       discovering stunning web UI components. Join us to contribute, learn,
       and inspire others!
     </p>
-
-    <a href="#faq" class="cta-btn bounce ripple btn-press"
-   onclick="event.preventDefault(); const el = document.getElementById('faq'); window.scrollTo({ top: el.offsetTop - 70, behavior: 'smooth' });">
-   Get Started
-</a>
     <div class="hero-buttons animated delay-3">
-      <a href="#faq" class="cta-btn ripple btn-press">Get Started</a>
+      <a href="#faq" class="cta-btn ripple btn-press"  onclick="event.preventDefault(); const el = document.getElementById('faq'); window.scrollTo({ top: el.offsetTop - 70, behavior: 'smooth' });">Get Started</a>
       <a href="editor.html" target="_blank" class="editor-btn ripple btn-press" rel="noopener noreferrer">
         <i class="fas fa-code"></i> Code Editor
       </a>


### PR DESCRIPTION
# 🚀 Pull Request

## 📄 Description
<!-- Describe your changes in detail -->
I noticed that the project had two "Get Started" buttons in the same section, which made the UI look a bit cluttered.
This PR removes the extra button to make the layout cleaner and less filled.
Fixes #975 

## 🛠️ Type of Change
<!-- Please delete options that are not relevant. -->

- [ x ] Other (please describe): Enhancement 

## ✅ Checklist
- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] I have linked the issue using `Fixes #issue_number`

## 📸 Screenshots (if available)
<!-- Add screenshots/gifs to explain what you changed -->
![image](url)
<img width="1750" height="794" alt="image" src="https://github.com/user-attachments/assets/6cb9c7c6-8c0c-4f17-b9f6-259e66a3dfe1" />
<img width="1736" height="804" alt="Screenshot 2025-08-16 085430" src="https://github.com/user-attachments/assets/58f84939-079e-4c3c-aaa3-f3fd19123275" />


## 📚 Related Issues
<!-- List any related issues, discussions, or pull requests -->

## 🧠 Additional Context
<!-- Any other information about this PR -->
 UI looks cleaner after removing the duplicate button
 No broken links or functionality
 Tested on local environment
