### PR TITLE
Fixing editor tab to open in same tab

### DIFF
--- a/about.html
+++ b/about.html
@@ -28,7 +28,7 @@
         <li><a href="index.html">Home</a></li>
         <!-- make active to About as you are in about -->
         <li><a href="about.html" class="active">About</a></li>
-        <li><a href="editor.html" target="_blank">Editor</a></li>
+        <li><a href="editor.html">Editor</a></li>
         <li><a href="templates.html">Templates</a></li>
         <li><a href="playground.html" style="white-space: nowrap">Hover-Effects</a></li>
         <li><a href="contributors.html">Contributors</a></li>

--- a/contact.html
+++ b/contact.html
@@ -28,7 +28,7 @@
       <ul class="nav-links">
         <li><a href="index.html">Home</a></li>
         <li><a href="about.html">About</a></li>
-        <li><a href="editor.html" target="_blank">Editor</a></li>
+        <li><a href="editor.html">Editor</a></li>
         <li><a href="templates.html">Templates</a></li>
         <li><a href="playground.html" style="white-space: nowrap">Hover-Effects</a></li>
         <li><a href="contributors.html">Contributors</a></li>

--- a/contributors.html
+++ b/contributors.html
@@ -27,7 +27,7 @@
       <ul class="nav-links">
         <li><a href="index.html">Home</a></li>
         <li><a href="about.html">About</a></li>
-        <li><a href="editor.html" target="_blank">Editor</a></li>
+        <li><a href="editor.html">Editor</a></li>
         <li><a href="templates.html">Templates</a></li>
         <li><a href="playground.html" style="white-space: nowrap">Hover-Effects</a></li>
         <li><a href="contributors.html" class="active">Contributors</a></li>

--- a/editor.css
+++ b/editor.css
@@ -12,7 +12,7 @@
   color: #ffffff;
        /* sky-500, indigo-500, cyan-400 */
 
-    box-shadow: 0 2px 6px rgb(0, 0, 0);
+  box-shadow: 0 2px 6px rgb(0, 0, 0);
   letter-spacing: 0.5px;
   font-size: 1rem;
   height: 60px; /* sets label height to 48px */
@@ -26,7 +26,7 @@
 
 .html-label {
   /* background-color: #fee2e2; */
-background: linear-gradient(270deg, #c976ea, #6366f1, #3f8f9b);
+  background: linear-gradient(270deg, #c976ea, #6366f1, #3f8f9b);
   font-size: 1.3rem;
   color: #001551;
 }
@@ -54,8 +54,8 @@ background: linear-gradient(270deg, #c976ea, #6366f1, #3f8f9b);
   background-color: rgba(255, 255, 255, 0.654);
   border-radius: 0 0 0.5rem 0.5rem;
   border-width: 1px;
-border: 2px solid #94a3b8; /* slate-400 */
-    box-shadow: 0 0 6px rgba(0, 0, 0, 0.508);
+  border: 2px solid #94a3b8; /* slate-400 */
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.508);
 
 
 }

--- a/editor.html
+++ b/editor.html
@@ -1,16 +1,61 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>AnimateItNow - Live Editor</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="editor.css" />
-  </head>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Editor | AnimateItNow</title>
+  <meta name="description" content="A live HTML, CSS, JS editor for AnimateItNow contributors" />
 
-  <body class="bg-gray-50 text-gray-900 min-h-screen">
-    <header id="header-section" class="bg-white shadow p-4 flex items-center justify-between">
-      <h1 class="text-2xl font-bold text-blue-600">AnimateItNow</h1>
+  <link rel="icon" type="image/png" href="images/logo.png" />
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css">
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+
+<body class="bg-gray-50 text-gray-900 min-h-screen font-sans">
+
+  <!-- Navbar -->
+  <nav class="navbar scroll-fade">
+    <div class="nav-left">
+      <a href="index.html" class="logo-link">
+        <img src="images/logo.png" alt="AnimateItNow Logo" class="logo" />
+        <span class="site-name">Animate It Now</span>
+      </a>
+    </div>
+
+    <div class="nav-right">
+      <ul class="nav-links">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="about.html">About</a></li>
+        <li><a href="editor.html" class="active">Editor</a></li>
+        <li><a href="templates.html">Templates</a></li>
+        <li><a href="playground.html" style="white-space: nowrap">Hover-Effects</a></li>
+        <li><a href="contributors.html">Contributors</a></li>
+        <li><a href="contact.html">Contact</a></li>
+        <li><a href="leaderboard.html">Leaderboard</a></li>
+        <li class="snakeList">
+          <label class="switch" title="Toggle Snake Cursor">
+            <input type="checkbox" id="cursorToggle">
+            <span class="slider round"></span>
+          </label>
+          <span class="snakeLabel">Snake Cursor</span>
+        </li>
+        <li>
+          <a href="https://github.com/itsAnimation/AnimateItNow" target="_blank" rel="noopener noreferrer" aria-label="GitHub Repo" class="github-icon">
+            <svg viewBox="0 0 16 16" width="24" height="24" fill="currentColor">
+              <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59..."></path>
+            </svg>
+          </a>
+        </li>
+        <li><button id="theme-toggle" aria-label="Toggle Theme"><i data-lucide="moon"></i></button></li>
+      </ul>
+    </div>
+  </nav>
+
+  <!-- Editor Content -->
+  <main class="p-6 max-w-7xl mx-auto space-y-8">
+    <header id="header-section" class="bg-white shadow p-4 flex items-center justify-between rounded">
+      <h1 class="text-2xl font-bold text-blue-600">Live Editor</h1>
       <div class="flex gap-2">
         <button
           id="resetBtn"
@@ -28,50 +73,104 @@
       </div>
     </header>
 
-    <main class="p-6 space-y-6">
-      <div class="flex flex-row gap-4">
-        <!-- HTML Editor -->
-        <div class="flex-1">
-          <div class="editor-label html-label">HTML</div>
-          <textarea
-            id="htmlCode"
-            class="editor-area html-area"
-            placeholder="Write HTML here..."
-          ></textarea>
-        </div>
-
-        <!-- CSS Editor -->
-        <div class="flex-1">
-          <div class="editor-label css-label">CSS</div>
-          <textarea
-            id="cssCode"
-            class="editor-area css-area"
-            placeholder="Write CSS here..."
-          ></textarea>
-        </div>
-
-        <!-- JS Editor -->
-        <div class="flex-1">
-          <div class="editor-label js-label">JavaScript</div>
-          <textarea
-            id="jsCode"
-            class="editor-area js-area"
-            placeholder="Write JavaScript here..."
-          ></textarea>
-        </div>
+    <div class="flex flex-col lg:flex-row gap-6">
+      <!-- HTML Editor -->
+      <div class="flex-1">
+        <div class="editor-label font-semibold text-purple-600 mb-1">HTML</div>
+        <textarea
+          id="htmlCode"
+          class="editor-area w-full h-60 p-3 rounded border border-gray-300"
+          placeholder="Write HTML here..."
+        ></textarea>
       </div>
 
-      <!-- Output -->
-      <div>
-        <h2 class="Output-line">Output</h2>
-        <iframe
-          id="output"
-          class="w-full h-[300px] border border-gray-300 rounded bg-white"
-        ></iframe>
+      <!-- CSS Editor -->
+      <div class="flex-1">
+        <div class="editor-label font-semibold text-green-600 mb-1">CSS</div>
+        <textarea
+          id="cssCode"
+          class="editor-area w-full h-60 p-3 rounded border border-gray-300"
+          placeholder="Write CSS here..."
+        ></textarea>
       </div>
-    </main>
 
-    <script src="editor.js"></script>
-  </body>
+      <!-- JS Editor -->
+      <div class="flex-1">
+        <div class="editor-label font-semibold text-yellow-600 mb-1">JavaScript</div>
+        <textarea
+          id="jsCode"
+          class="editor-area w-full h-60 p-3 rounded border border-gray-300"
+          placeholder="Write JavaScript here..."
+        ></textarea>
+      </div>
+    </div>
+
+    <!-- Output -->
+    <div>
+      <h2 class="text-xl font-semibold text-purple-700 mb-2">Output</h2>
+      <iframe
+        id="output"
+        class="w-full h-[300px] border border-gray-300 rounded bg-white"
+      ></iframe>
+    </div>
+  </main>
+
+  <!-- Footer -->
+  <footer class="footer scroll-fade">
+    <div class="footer-content">
+      <div class="footer-left">
+        <h2>AnimateItNow</h2>
+        <p>Creating impactful web animations and templates for everyone.</p>
+      </div>
+      <div class="footer-right">
+        <h4>Connect With Us</h4>
+        <ul>
+          <li><a href="https://github.com/itsAnimation/AnimateItNow" target="_blank" rel="noopener noreferrer"><i class="fab fa-github fa-beat"></i> GitHub</a></li> 
+          <li><a href="https://www.linkedin.com/in/anujshrivastava1/" target="_blank" rel="noopener noreferrer"><i class="fab fa-linkedin fa-beat"></i> LinkedIn</a></li>
+          <li><a href="mailto:contact@animateitnow.com" rel="noopener noreferrer"><i class="fas fa-envelope fa-beat"></i> Email Us</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <p>© 2025 AnimateItNow. Made with ❤️ by <span class="highlight">Anuj</span> and Contributors.</p>
+    </div>
+  </footer>
+
+  <div id="cursor-snake"></div>
+
+  <!-- Scripts -->
+  <script src="https://unpkg.com/lucide@latest"></script>
+  <script>
+    const themeToggle = document.getElementById('theme-toggle');
+    const body = document.body;
+
+    function setTheme(isDark) {
+      const newIcon = isDark ? 'sun' : 'moon';
+      body.classList.toggle('dark-theme', isDark);
+      localStorage.setItem('theme', isDark ? 'dark' : 'light');
+
+      if (themeToggle) {
+        themeToggle.innerHTML = `<i data-lucide="${newIcon}"></i>`;
+        lucide.createIcons();
+      }
+    }
+
+    const savedTheme = localStorage.getItem('theme');
+    const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    setTheme(savedTheme === 'dark' || (savedTheme === null && prefersDark));
+
+    themeToggle?.addEventListener('click', () => {
+      setTheme(!body.classList.contains('dark-theme'));
+    });
+
+    document.addEventListener('DOMContentLoaded', () => {
+      if (window.lucide) {
+        lucide.createIcons();
+      }
+    });
+  </script>
+  <script src="editor.js"></script>
+  <script src="script.js"></script>
+  <script src="pwa.js"></script>
+</body>
 </html>
-

--- a/index.html
+++ b/index.html
@@ -58,7 +58,9 @@
       <ul class="nav-links">
         <li><a href="index.html" class="active">Home</a></li>
         <li><a href="about.html">About</a></li>
+        <li><a href="editor.html">Editor</a></li>
         <li><a href="templates.html">Templates</a></li>
+        <li><a href="playground.html" style="white-space: nowrap">Hover-Effects</a></li>
         <li><a href="contributors.html">Contributors</a></li>
         <li><a href="contact.html">Contact</a></li>
         <li><a href="leaderboard.html">Leaderboard</a></li>  <!--leaderboard linkup> -->

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -556,7 +556,9 @@
   <ul class="nav-links">
     <li><a href="index.html">Home</a></li>
     <li><a href="about.html">About</a></li>
+    <li><a href="editor.html">Editor</a></li>
     <li><a href="templates.html">Templates</a></li>
+    <li><a href="playground.html" style="white-space: nowrap">Hover-Effects</a></li>
     <li><a href="contributors.html">Contributors</a></li>
     <li><a href="contact.html">Contact</a></li>
     <li><a href="leaderboard.html" class="active">Leaderboard</a></li>

--- a/playground.html
+++ b/playground.html
@@ -50,8 +50,9 @@
         <li><a href="index.html">Home</a></li>
         <!-- make active to About as you are in about -->
         <li><a href="about.html" class="active">About</a></li>
+        <li><a href="editor.html">Editor</a></li>
         <li><a href="templates.html">Templates</a></li>
-        <li><a href="playground.html" style="white-space: nowrap">Hover-Effects</a></li>
+        <li><a href="playground.html" style="white-space: nowrap" class="active">Hover-Effects</a></li>
         <li><a href="contributors.html">Contributors</a></li>
         <li><a href="contact.html">Contact</a></li>
         <li><a href="leaderboard.html">Leaderboard</a></li>

--- a/templates.html
+++ b/templates.html
@@ -547,7 +547,7 @@
         <ul class="nav-links">
           <li><a href="index.html">Home</a></li>
           <li><a href="about.html">About</a></li>
-          <li><a href="editor.html" target="_blank">Editor</a></li>
+          <li><a href="editor.html">Editor</a></li>
           <li><a href="templates.html" class="active">Templates</a></li>
           <li><a href="playground.html" style="white-space: nowrap">Hover-Effects</a></li>
           <li><a href="contributors.html">Contributors</a></li>


### PR DESCRIPTION
# 🚀 Pull Request

## 📄 Description
Fixed the issue where the Editor link opened in a new tab due to the presence of target="_blank" in the code. Now the editor loads in the same tab, improving navigation consistency across the site.
Also, when hover-effects and leaderboard was clicked then about and editor would disappear from the navbar as link reference was not there, so it was also fixed. 
Fixes #841 

## 🛠️ Type of Change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix 🐛
- [ ] New feature ✨
- [ ] Code refactor 🔨
- [ ] Documentation update 📚
- [ ] Other (please describe):

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have linked the issue using `Fixes #issue_number`

## 📸 Screenshots (if available)
<!-- Add screenshots/gifs to explain what you changed -->
![image](url)

## 📚 Related Issues
<!-- List any related issues, discussions, or pull requests -->

## 🧠 Additional Context
<!-- Any other information about this PR -->
