### PR TITLE
Added 'Copy to Clipboard' Button for Code Snippets/Templates

### DIFF
--- a/editor.css
+++ b/editor.css
@@ -1,45 +1,33 @@
-
-
-
-
 .editor-label {
-  
   font-weight: bold;
   padding: 0.5rem 1rem;
   border-top-left-radius: 0.5rem;
   border-top-right-radius: 0.5rem;
   background-size: 600% 600%;
   color: #ffffff;
-       /* sky-500, indigo-500, cyan-400 */
-
-    box-shadow: 0 2px 6px rgb(0, 0, 0);
+  box-shadow: 0 2px 6px rgb(0, 0, 0);
   letter-spacing: 0.5px;
   font-size: 1rem;
-  height: 60px; /* sets label height to 48px */
+  height: 60px;
   display: flex;
-  align-items: center; /* vertically center the text */
- 
+  align-items: center;
+  justify-content: space-between;
+  position: relative;
 }
 
-
-
-
 .html-label {
-  /* background-color: #fee2e2; */
-background: linear-gradient(270deg, #c976ea, #6366f1, #3f8f9b);
+  background: linear-gradient(270deg, #c976ea, #6366f1, #3f8f9b);
   font-size: 1.3rem;
   color: #001551;
 }
 
 .css-label {
-  /* background-color: #dbeafe; */
   background: linear-gradient(270deg, #2be90e, #6366f1, #22ebee);
   font-size: 1.3rem;
   color: #001551;
 }
 
 .js-label {
-  /* background-color: #d1fae5; */
   background: linear-gradient(270deg, #e9e90e, #6366f1, #22d3ee);
   font-size: 1.3rem;
   color: #001551;
@@ -54,23 +42,22 @@ background: linear-gradient(270deg, #c976ea, #6366f1, #3f8f9b);
   background-color: rgba(255, 255, 255, 0.654);
   border-radius: 0 0 0.5rem 0.5rem;
   border-width: 1px;
-border: 2px solid #94a3b8; /* slate-400 */
-    box-shadow: 0 0 6px rgba(0, 0, 0, 0.508);
-
-
+  border: 2px solid #94a3b8;
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.508);
 }
+
 .editor-area:hover {
   transform: scale(1.01);
   box-shadow: 0 12px 36px rgba(0, 0, 0, 0.15);
 }
+
 #output {
   border-radius: 1rem;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
   transition: all 0.3s ease;
-  border: 2px solid #94a3b8; /* slate-400 */
+  border: 2px solid #94a3b8;
   background: linear-gradient(to bottom, #f1f5f9, #ffffff);
   box-shadow: 0 0 6px rgba(0, 0, 0, 0.677);
-
 }
 
 #output:hover {
@@ -78,23 +65,52 @@ border: 2px solid #94a3b8; /* slate-400 */
   box-shadow: 0 12px 36px rgba(0, 0, 0, 0.15);
 }
 
-
 .Output-line {
-  font-size: 1.75rem; /* larger heading */
+  font-size: 1.75rem;
   font-weight: 800;
   padding: 0.75rem 1.5rem;
   margin-bottom: 1rem;
   border-radius: 0.75rem;
   background: rgba(254, 254, 254, 0.05);
-  
   border: 1px solid rgba(255, 255, 255, 0.2);
-  border-left:7px solid #220149 ;
+  border-left: 7px solid #220149;
   color: #380475;
-  
-  
   text-align: left;
   letter-spacing: 1px;
-  box-shadow: 0 4px 20px rgb(150, 140, 160); /* subtle blue glow */
-  
+  box-shadow: 0 4px 20px rgb(150, 140, 160);
 }
 
+/* Copy button styles */
+.copy-btn {
+  background: rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  color: #001551;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.copy-btn:hover {
+  background: rgba(255, 255, 255, 0.3);
+  transform: scale(1.05);
+}
+
+.copy-tooltip {
+  position: absolute;
+  right: 1rem;
+  top: -2rem;
+  background: rgba(0, 0, 0, 0.8);
+  color: white;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  pointer-events: none;
+}
+
+.copy-tooltip.show {
+  opacity: 1;
+}

--- a/editor.html
+++ b/editor.html
@@ -32,7 +32,13 @@
       <div class="flex flex-row gap-4">
         <!-- HTML Editor -->
         <div class="flex-1">
-          <div class="editor-label html-label">HTML</div>
+          <div class="editor-label html-label">
+            <span>HTML</span>
+            <button class="copy-btn" data-target="htmlCode" title="Copy HTML">
+              📋
+            </button>
+            <div class="copy-tooltip">Copied!</div>
+          </div>
           <textarea
             id="htmlCode"
             class="editor-area html-area"
@@ -42,7 +48,13 @@
 
         <!-- CSS Editor -->
         <div class="flex-1">
-          <div class="editor-label css-label">CSS</div>
+          <div class="editor-label css-label">
+            <span>CSS</span>
+            <button class="copy-btn" data-target="cssCode" title="Copy CSS">
+              📋
+            </button>
+            <div class="copy-tooltip">Copied!</div>
+          </div>
           <textarea
             id="cssCode"
             class="editor-area css-area"
@@ -52,7 +64,13 @@
 
         <!-- JS Editor -->
         <div class="flex-1">
-          <div class="editor-label js-label">JavaScript</div>
+          <div class="editor-label js-label">
+            <span>JavaScript</span>
+            <button class="copy-btn" data-target="jsCode" title="Copy JavaScript">
+              📋
+            </button>
+            <div class="copy-tooltip">Copied!</div>
+          </div>
           <textarea
             id="jsCode"
             class="editor-area js-area"
@@ -74,4 +92,3 @@
     <script src="editor.js"></script>
   </body>
 </html>
-

--- a/editor.js
+++ b/editor.js
@@ -37,3 +37,27 @@ document.getElementById("resetBtn").addEventListener("click", () => {
   output.srcdoc = "<!DOCTYPE html><html><body></body></html>";
 });
 
+// Copy to clipboard functionality
+document.querySelectorAll('.copy-btn').forEach(btn => {
+  btn.addEventListener('click', async (e) => {
+    const targetId = e.target.getAttribute('data-target');
+    const textarea = document.getElementById(targetId);
+    const tooltip = e.target.parentElement.querySelector('.copy-tooltip');
+    
+    try {
+      await navigator.clipboard.writeText(textarea.value);
+      tooltip.classList.add('show');
+      setTimeout(() => {
+        tooltip.classList.remove('show');
+      }, 1500);
+    } catch (err) {
+      // Fallback for older browsers
+      textarea.select();
+      document.execCommand('copy');
+      tooltip.classList.add('show');
+      setTimeout(() => {
+        tooltip.classList.remove('show');
+      }, 1500);
+    }
+  });
+});


### PR DESCRIPTION
# 🚀 Pull Request

## 📄 Description
Added "Copy to Clipboard" functionality to the live editor interface. Users can now easily copy HTML, CSS, and JavaScript code from each editor panel with a single click, eliminating the need for manual text selection
Fixes #943 

## 🛠️ Type of Change
- [x] New feature ✨

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas


## 📸 Screenshots (if available)
Before : Users had to manually select and copy code from editor panels

<img width="1919" height="965" alt="image" src="https://github.com/user-attachments/assets/79eeadbe-1d64-402c-afe1-c5478256974d" />


After : Added clipboard buttons (📋) in each editor header
Click to copy functionality with visual feedback
"Copied!" tooltip confirmation appears for 1.5 seconds

<img width="1919" height="966" alt="image" src="https://github.com/user-attachments/assets/fe0ee5fc-5482-498a-b773-c8710d1963a0" />

Files Modified:

editor.html - Added copy buttons to editor labels
editor.css - Added styles for copy buttons and tooltips
editor.js - Implemented clipboard functionality

🎯 User Benefits:

Improved Usability: Reduces manual steps for copying code
Faster Workflow: One-click copying instead of select-all + copy
Better UX: Clear visual feedback confirms successful copy action
Cross-browser Support: Works in both modern and legacy browsers

🧪 Testing:

 Tested copy functionality in Chrome, Firefox, Safari
 Verified fallback works in older browser versions
 Confirmed tooltips appear and disappear correctly
 Validated button styling matches design system
 Tested with empty and populated editor content
 
 Kindly check it out
@SurajSG23 