### PR TITLE
Feature/save templates feature added

### DIFF
--- a/saved-templates.html
+++ b/saved-templates.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Saved Templates - Animate It Now</title>
+    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="themes.css" />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
+    />
+
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        background-color: #0e0e0e;
+        color: #fff;
+        margin: 0;
+        padding: 0;
+      }
+
+      header {
+        background: #111;
+        padding: 15px 20px;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+
+      header h1 {
+        color: #0ff;
+        font-size: 1.6rem;
+      }
+
+      .container {
+        max-width: 1200px;
+        margin: 30px auto;
+        padding: 0 20px;
+      }
+
+      .templates-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+        gap: 20px;
+      }
+
+      .template-card {
+        position: relative;
+        background: #1c1c1c;
+        padding: 15px;
+        border-radius: 12px;
+        box-shadow: 0 0 10px rgba(0, 255, 255, 0.2);
+        transition: transform 0.2s ease;
+        text-decoration: none;
+        color: inherit;
+      }
+
+      .template-card:hover {
+        transform: scale(1.05);
+      }
+
+      .template-card h2 {
+        font-size: 1.1rem;
+        margin-bottom: 10px;
+      }
+
+      .template-btn {
+        display: inline-block;
+        margin-top: 10px;
+        padding: 8px 14px;
+        border: none;
+        border-radius: 8px;
+        background: #0ff;
+        color: #000;
+        font-weight: bold;
+        cursor: pointer;
+        text-align: center;
+        text-decoration: none;
+      }
+
+      .template-btn:hover {
+        background: #00c2c2;
+      }
+
+      .no-favorites {
+        text-align: center;
+        margin-top: 50px;
+        font-size: 1.3rem;
+        color: #bbb;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>⭐ Saved Templates</h1>
+      <a href="templates.html" class="template-btn">← Back to Templates</a>
+    </header>
+
+    <div class="container">
+      <div id="favorites-container" class="templates-grid"></div>
+      <p id="no-favorites" class="no-favorites" style="display: none">
+        You haven’t saved any templates yet.
+      </p>
+    </div>
+
+    <script>
+      // Load Favorites from localStorage
+      const favorites = JSON.parse(localStorage.getItem("favorites")) || [];
+      const container = document.getElementById("favorites-container");
+      const noFavMessage = document.getElementById("no-favorites");
+
+      // Templates list (must match IDs used in templates.html)
+      const templates = {
+        "login-form-glassmorphism": {
+          title: "Login Form with Glassmorphism.",
+          link: "templates/LoginFormGlassMorphism.html",
+        },
+        "login-page-ui": {
+          title: "Login Page UI",
+          link: "templates/login.html",
+        },
+        "hover-button-effects": {
+          title: "Hover Button Effects",
+          link: "templates/button.html",
+        },
+        loaders: {
+          title: "Loaders",
+          link: "templates/loader.html",
+        },
+        "text-animation-effects": {
+          title: "Text Animation Effects",
+          link: "templates/text_effects_anim.html",
+        },
+        "popup-templates": {
+          title: "Popup Templates",
+          link: "templates/modal.html",
+        },
+        "glassmorphism-profile-card": {
+          title: "Glassmorphism profile card",
+          link: "templates/glassmorphism.html",
+        },
+        "code-playground": {
+          title: "Code PlayGround",
+          link: "templates/code_playground.html",
+        },
+        "feature-cards-ui": {
+          title: "Feature Cards UI",
+          link: "templates/feature.html",
+        },
+        "hero-section-template": {
+          title: "Hero Section Template",
+          link: "templates/hero.html",
+        },
+        "animated-button": {
+          title: "Animated Button",
+          link: "templates/animated-btn.html",
+        },
+        "animated-social-share-buttons": {
+          title: "Animated Social Share Buttons",
+          link: "templates/social-share-buttons.html",
+        },
+        "tooltip-ui-component": {
+          title: "Tooltip UI Component",
+          link: "templates/tooltip.html",
+        },
+        "responsive-card-carousel": {
+          title: "Responsive Card Carousel",
+          link: "templates/carousel.html",
+        },
+        "animated-toggles": {
+          title: "Animated Toggles",
+          link: "templates/toggles-and-checkboxes.html",
+        },
+        "neumorphic-button-effects": {
+          title: "Neumorphic Button Effects",
+          link: "templates/neumorphic.html",
+        },
+        "navbar-variants": {
+          title: "Navbar Variants",
+          link: "templates/navbar.html",
+        },
+        "display-properties": {
+          title: "Display Properties",
+          link: "templates/display.html",
+        },
+        "3d-card-hover-effects": {
+          title: "3D Card Hover Effects",
+          link: "templates/CardHoverEffects.html",
+        },
+        "404-page-not-found": {
+          title: "404 Page not found",
+          link: "templates/page_not_found_template.html",
+        },
+        "contact-us-template": {
+          title: "Contact Us Template",
+          link: "templates/contact.html",
+        },
+        "accordian-template": {
+          title: "Accordian Template",
+          link: "templates/accordian.html",
+        },
+      };
+
+      // If no favorites → show message
+      if (favorites.length === 0) {
+        noFavMessage.style.display = "block";
+      } else {
+        favorites.forEach((id) => {
+          if (templates[id]) {
+            const card = document.createElement("a");
+            card.classList.add("template-card");
+            card.href = templates[id].link;
+            card.innerHTML = `
+            <h2>${templates[id].title}</h2>
+            <button class="template-btn">View Template</button>
+            `;
+            container.appendChild(card);
+          }
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/saved-templates.html
+++ b/saved-templates.html
@@ -90,20 +90,61 @@
     <link rel="stylesheet" href="templates.css" />
 
     <style>
-      /* Keeping some specific styles for this page */
-      .container {
-        max-width: 1200px;
-        margin: 30px auto;
-        padding: 0 20px;
+      /* Remove margins to prevent light-space bleed */
+      body, html {
+        margin: 0;
+        padding: 0;
+        width: 100%;
+        overflow-x: hidden;
       }
 
-      .templates-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-        gap: 20px;
+      /* Navbar fixes */
+      .navbar {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+        position: fixed;
+        width: 100%;
+      }
+      .nav-right {
+        display: flex;
+        gap: 1.5rem;
+      }
+      a {
+        text-decoration: none;
       }
 
-      /* Card and button styles for dark mode from templates.html */
+      /* Dark Mode Global Styles */
+      body.dark {
+        background-color: #121212;
+        color: #f5f5f5;
+        background: url(images/bgdark.png) no-repeat center center fixed;
+        background-size: cover;
+        background-position: center;
+      }
+
+      /* Navbar dark mode */
+      body.dark .navbar,
+      body.dark .nav-links a,
+      body.dark .site-name {
+        background-color: #1a1a1a;
+        color: #ffffff;
+      }
+      body.dark .nav-links a:hover {
+        color: #90caf9;
+      }
+
+      /* Headings dark mode */
+      body.dark .templates-main h1 {
+        background: linear-gradient(to right, #67e8f9, #3b82f6);
+        -webkit-background-clip: text;
+        background-clip: text;
+        -webkit-text-fill-color: transparent;
+        text-shadow: 0 2px 10px rgba(56, 189, 248, 0.4);
+      }
+
+      /* Template card dark mode */
       body.dark .template-card {
         background-color: rgba(30, 41, 59, 0.6);
         border: 1px solid rgba(59, 130, 246, 0.15);
@@ -124,6 +165,35 @@
         background-color: #444;
         color: #ffffff;
       }
+
+      /* Dark mode template preview */
+      body.dark .template-preview {
+        background-color: #2a2a2a;
+        box-shadow: 0 2px 6px rgb(255 255 255 / 0.1);
+      }
+
+      /* Smooth transitions */
+      .templates-main h1,
+      .template-card h2,
+      .template-btn,
+      .navbar,
+      .nav-links a {
+        transition: color 0.3s ease, background-color 0.3s ease;
+      }
+
+      /* Keeping specific styles for this page */
+      .container {
+        max-width: 1200px;
+        margin: 30px auto;
+        padding: 0 20px;
+      }
+
+      .templates-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+        gap: 20px;
+      }
+
       .template-card:hover {
         transform: scale(1.05);
       }
@@ -132,17 +202,14 @@
         margin-top: 10px;
         padding: 8px 14px;
         border: none;
-        border-radius: 8px;
-        /* background: #0ff; */
+        border-radius: 40px;
         color: #000;
         font-weight: bold;
         cursor: pointer;
         text-align: center;
         text-decoration: none;
       }
-      a {
-        text-decoration: none;
-      }
+
       /* FIX: Removed underline on card titles */
       a.template-card h2 {
         text-decoration: none;
@@ -154,11 +221,17 @@
         font-size: 1.3rem;
         color: #bbb;
       }
+
       /* Ensure the page title is styled correctly */
       .templates-main h1 {
         text-align: center;
         margin-bottom: 2rem;
+        background: linear-gradient(to right, #007bff, #0056b3);
+        -webkit-background-clip: text;
+        background-clip: text;
+        -webkit-text-fill-color: transparent;
       }
+
       /* New CSS for the button and header container */
       .saved-templates-header {
         display: flex;
@@ -190,17 +263,20 @@
       .back-to-templates-btn:hover {
         background-color: #ff2c4f;
       }
+
       /* Hiding the heart icon on this page */
       .favorite-btn {
         display: none !important;
       }
+
       /* New style for the remove button */
       .remove-btn {
         display: inline-block;
         margin-top: 10px;
+        margin-left: 10px;
         padding: 8px 14px;
         border: none;
-        border-radius: 8px; /* FIX: Changed from 20px to 8px */
+        border-radius: 40px;
         background: #ff4d6d;
         color: white;
         font-weight: bold;
@@ -208,8 +284,7 @@
         text-align: center;
         text-decoration: none;
         transition: background-color 0.3s ease;
-        margin-left: 5px;
-
+        position: relative;
       }
       .remove-btn:hover {
         background-color: #ff2c4f;
@@ -237,21 +312,263 @@
           grid-template-columns: 1fr;
         }
       }
-      /* New style for the template title on saved page for consistency */
-      .templates-main h1 {
-        background: linear-gradient(
-          to right,
-          #67e8f9,
-          #3b82f6
-        ); /*bright neon cyan-blue */
-        -webkit-background-clip: text;
-        background-clip: text;
-        -webkit-text-fill-color: transparent;
-        text-shadow: 0 2px 10px rgba(56, 189, 248, 0.4);
+
+      /* Logo link styling */
+      .logo-link {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        text-decoration: none;
+        color: inherit;
+      }
+
+      .logo-link img.logo {
+        height: 40px;
+        width: auto;
+      }
+
+      .site-name {
+        font-size: 1.2rem;
+        font-weight: bold;
+        pointer-events: none;
+      }
+
+      .logo-link:hover {
+        opacity: 0.8;
+        cursor: pointer;
+      }
+
+      /* Base preview style */
+      .template-preview {
+        height: 90px;
+        border-radius: 10px;
+        margin-bottom: 12px;
+        background-color: #f0f0f0;
+        box-shadow: 0 2px 6px rgb(0 0 0 / 0.1);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        padding: 10px;
+        box-sizing: border-box;
+      }
+
+      /* Feature Cards Preview */
+      .feature-preview {
+        background-color: #4f8cff;
+        padding: 12px;
+        gap: 10px;
+      }
+      .feature-preview .mini-card {
+        background-color: white;
+        flex: 1;
+        border-radius: 6px;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+        height: 60px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 12px;
+        color: #555;
+        font-weight: 600;
+      }
+
+      /* Hero Section Preview */
+      .hero-preview {
+        background-color: #4f8cff;
+        flex-direction: column;
+        padding: 14px;
+        gap: 8px;
+      }
+      .hero-preview .hero-image {
+        background-color: white;
+        border-radius: 8px;
+        width: 100%;
+        height: 50px;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+      }
+      .hero-preview .hero-text-line {
+        background-color: white;
+        border-radius: 5px;
+        height: 8px;
+        width: 80%;
+        box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+      }
+      .hero-preview .hero-text-line.short {
+        width: 50%;
+      }
+
+      /* Social Share Preview */
+      .social-share-preview {
+        background-color: #4f8cff;
+        gap: 15px;
+        font-size: 28px;
+        color: white;
+      }
+      .social-share-preview .social-icon-preview {
+        transition: transform 0.2s ease-in-out;
+      }
+      .social-share-preview:hover .social-icon-preview {
+        transform: scale(1.1);
+      }
+
+      /* Navbar Preview */
+      .navbar-preview {
+        background-color: #4f8cff;
+        flex-direction: column;
+        justify-content: center;
+        padding: 12px;
+        gap: 8px;
+      }
+      .navbar-line {
+        height: 10px;
+        border-radius: 5px;
+        background-color: white;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+      }
+      .navbar-line.logo {
+        width: 40%;
+      }
+      .navbar-line.link {
+        width: 70%;
+      }
+      .navbar-line.link.short {
+        width: 50%;
+      }
+
+      /* Animated Toggles Preview */
+      .toggles-preview {
+        background-color: #4f8cff;
+        gap: 20px;
+      }
+      .mini-toggle {
+        width: 50px;
+        height: 25px;
+        background-color: #ccc;
+        border-radius: 25px;
+        position: relative;
+        padding: 3px;
+        box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.2);
+      }
+      .mini-handle {
+        width: 19px;
+        height: 19px;
+        background-color: white;
+        border-radius: 50%;
+        position: absolute;
+        transition: transform 0.3s ease;
+      }
+      .mini-toggle.off .mini-handle {
+        transform: translateX(0);
+      }
+      .mini-toggle.on {
+        background-color: #25d366;
+      }
+      .mini-toggle.on .mini-handle {
+        transform: translateX(25px);
+      }
+
+      /* Display Properties Preview */
+      .display-preview {
+        background-color: #4f8cff;
+        height: 90px;
+        border-radius: 10px;
+        margin-bottom: 12px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: 8px;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+      }
+      .display-box {
+        border-radius: 4px;
+        display: inline-block;
+      }
+      .display-box.box1 {
+        width: 24px;
+        height: 24px;
+        background-color: #bbdefb;
+      }
+      .display-box.box2 {
+        width: 24px;
+        height: 32px;
+        background-color: #90caf9;
+      }
+      .display-box.box3 {
+        width: 24px;
+        height: 28px;
+        background-color: #64b5f6;
+      }
+
+      .code-play-preview {
+        font-size: 1rem;
+        font-weight: bold;
+      }
+
+      /* Dark Theme Support for previews */
+      body.dark .display-preview {
+        background-color: #2a2a2a;
+        box-shadow: 0 2px 6px rgba(255, 255, 255, 0.1);
+      }
+
+      /* Switch component for cursor toggle */
+      .switch {
+        position: relative;
+        display: inline-block;
+        width: 60px;
+        height: 34px;
+      }
+
+      .switch input {
+        opacity: 0;
+        width: 0;
+        height: 0;
+      }
+
+      .slider {
+        position: absolute;
+        cursor: pointer;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: #ccc;
+        transition: .4s;
+      }
+
+      .slider:before {
+        position: absolute;
+        content: "";
+        height: 26px;
+        width: 26px;
+        left: 4px;
+        bottom: 4px;
+        background-color: white;
+        transition: .4s;
+      }
+
+      input:checked + .slider {
+        background-color: #007bff;
+      }
+
+      input:focus + .slider {
+        box-shadow: 0 0 1px #007bff;
+      }
+
+      input:checked + .slider:before {
+        transform: translateX(26px);
+      }
+
+      .slider.round {
+        border-radius: 34px;
+      }
+
+      .slider.round:before {
+        border-radius: 50%;
       }
     </style>
   </head>
-  <body>
+  <body class="dark">
     <nav class="navbar scroll-fade">
       <div class="nav-left">
         <a href="index.html" class="logo-link">
@@ -320,7 +637,7 @@
       <div class="container">
         <div id="favorites-container" class="templates-grid"></div>
         <p id="no-favorites" class="no-favorites" style="display: none">
-          You haven’t saved any templates yet.
+          You haven't saved any templates yet.
         </p>
       </div>
     </main>
@@ -438,7 +755,7 @@
         "tooltip-ui-component": {
           title: "Tooltip UI Component",
           link: "templates/tooltip.html",
-          preview: `<div class="template-preview"><button class="tooltip" data-tooltip="I’m a tooltip!">Hover</button></div>`,
+          preview: `<div class="template-preview"><button class="tooltip" data-tooltip="I'm a tooltip!">Hover</button></div>`,
         },
         "responsive-card-carousel": {
           title: "Responsive Card Carousel",
@@ -511,29 +828,21 @@
               container.appendChild(card);
             }
           });
-          attachEventListeners();
         }
       }
 
-      function attachEventListeners() {
-        // Event listener for the remove button
-        document.querySelectorAll(".remove-btn").forEach((button) => {
-          button.addEventListener("click", (e) => {
-            e.preventDefault();
-            const templateId = button.getAttribute("data-id");
-            favorites = favorites.filter((id) => id !== templateId);
-            localStorage.setItem("favorites", JSON.stringify(favorites));
-            renderFavoriteCards(); // Re-render the cards after removal
-          });
-        });
+      // Function to handle removing a favorite template
+      function handleRemoveFavorite(e) {
+        if (e.target.classList.contains("remove-btn")) {
+          e.preventDefault();
+          const templateId = e.target.getAttribute("data-id");
+          favorites = favorites.filter((id) => id !== templateId);
+          localStorage.setItem("favorites", JSON.stringify(favorites));
+          renderFavoriteCards();
+        }
       }
 
-      // Initial render
-      renderFavoriteCards();
-
-      // =============================
-      // Theme Toggle Functionality
-      // =============================
+      // Theme toggle functionality
       const themeToggle = document.getElementById("theme-toggle");
       const body = document.body;
 
@@ -541,20 +850,31 @@
         const newIcon = isDark ? "sun" : "moon";
         body.classList.toggle("dark", isDark);
         localStorage.setItem("theme", isDark ? "dark" : "light");
+
         if (themeToggle) {
           themeToggle.innerHTML = `<i data-lucide="${newIcon}"></i>`;
           lucide.createIcons();
         }
       }
+
+      // Initialize theme based on saved preference or system preference
       const savedTheme = localStorage.getItem("theme");
       const prefersDark =
         window.matchMedia &&
         window.matchMedia("(prefers-color-scheme: dark)").matches;
       setTheme(savedTheme === "dark" || (savedTheme === null && prefersDark));
+
+      // Add click event listener to theme toggle button
       themeToggle?.addEventListener("click", () => {
         setTheme(!body.classList.contains("dark"));
       });
-      lucide.createIcons();
+      
+      // Initial render and event listener setup
+      document.addEventListener("DOMContentLoaded", () => {
+        renderFavoriteCards();
+        container.addEventListener("click", handleRemoveFavorite);
+        lucide.createIcons(); // Initialize Lucide icons on page load
+      });
     </script>
   </body>
 </html>

--- a/saved-templates.html
+++ b/saved-templates.html
@@ -3,36 +3,94 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Saved Templates - Animate It Now</title>
-    <link rel="stylesheet" href="style.css" />
-    <link rel="stylesheet" href="themes.css" />
+    <title>Saved Templates | AnimateItNow</title>
+    <meta name="theme-color" content="#ff6b6b" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-title" content="AnimateItNow" />
+    <meta
+      name="msapplication-TileImage"
+      content="images/icons/icon-144x144.png"
+    />
+    <meta name="msapplication-TileColor" content="#ff6b6b" />
+
+    <link rel="manifest" href="manifest.json" />
+
     <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
+      rel="icon"
+      type="image/png"
+      sizes="72x72"
+      href="images/icons/icon-72x72.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="96x96"
+      href="images/icons/icon-96x96.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="128x128"
+      href="images/icons/icon-128x128.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="144x144"
+      href="images/icons/icon-144x144.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="152x152"
+      href="images/icons/icon-152x152.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="192x192"
+      href="images/icons/icon-192x192.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="384x384"
+      href="images/icons/icon-384x384.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="512x512"
+      href="images/icons/icon-512x512.png"
     />
 
+    <link
+      rel="apple-touch-icon"
+      sizes="152x152"
+      href="images/icons/icon-152x152.png"
+    />
+    <link
+      rel="apple-touch-icon"
+      sizes="192x192"
+      href="images/icons/icon-192x192.png"
+    />
+
+    <link rel="icon" type="image/png" href="images/logo.png" />
+    <link rel="stylesheet" href="styles.css" />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css"
+    />
+    <link rel="stylesheet" href="themes.css" />
+    <link rel="stylesheet" href="templates.css" />
+
     <style>
-      body {
-        font-family: Arial, sans-serif;
-        background-color: #0e0e0e;
-        color: #fff;
-        margin: 0;
-        padding: 0;
-      }
-
-      header {
-        background: #111;
-        padding: 15px 20px;
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-      }
-
-      header h1 {
-        color: #0ff;
-        font-size: 1.6rem;
-      }
-
+      /* Keeping some specific styles for this page */
       .container {
         max-width: 1200px;
         margin: 30px auto;
@@ -45,26 +103,30 @@
         gap: 20px;
       }
 
-      .template-card {
-        position: relative;
-        background: #1c1c1c;
-        padding: 15px;
-        border-radius: 12px;
-        box-shadow: 0 0 10px rgba(0, 255, 255, 0.2);
-        transition: transform 0.2s ease;
-        text-decoration: none;
-        color: inherit;
+      /* Card and button styles for dark mode from templates.html */
+      body.dark .template-card {
+        background-color: rgba(30, 41, 59, 0.6);
+        border: 1px solid rgba(59, 130, 246, 0.15);
+        box-shadow: 0 0 6px rgba(59, 130, 246, 0.25),
+          0 0 12px rgba(56, 189, 248, 0.3);
+        color: #ffffff;
+        animation: darkNeonPulse 4s ease-in-out infinite;
       }
-
+      body.dark .template-card h2 {
+        color: #ffffff;
+      }
+      body.dark .template-btn {
+        color: #ffffff;
+        background-color: #333;
+        border: 1px solid #555;
+      }
+      body.dark .template-btn:hover {
+        background-color: #444;
+        color: #ffffff;
+      }
       .template-card:hover {
         transform: scale(1.05);
       }
-
-      .template-card h2 {
-        font-size: 1.1rem;
-        margin-bottom: 10px;
-      }
-
       .template-btn {
         display: inline-block;
         margin-top: 10px;
@@ -78,9 +140,12 @@
         text-align: center;
         text-decoration: none;
       }
-
-      .template-btn:hover {
-        background: #00c2c2;
+      a {
+        text-decoration: none;
+      }
+      /* FIX: Removed underline on card titles */
+      a.template-card h2 {
+        text-decoration: none;
       }
 
       .no-favorites {
@@ -89,136 +154,395 @@
         font-size: 1.3rem;
         color: #bbb;
       }
+      /* Ensure the page title is styled correctly */
+      .templates-main h1 {
+        text-align: center;
+        margin-bottom: 2rem;
+      }
+      /* New CSS for the button and header container */
+      .saved-templates-header {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: 20px;
+        position: relative;
+        margin-bottom: 1.5rem;
+      }
+
+      .saved-templates-header h1 {
+        margin: 0;
+      }
+
+      .back-to-templates-btn {
+        position: absolute;
+        right: 0;
+        top: 50%;
+        transform: translateY(-50%);
+        padding: 8px 16px;
+        background-color: #007bff;
+        color: white;
+        border: none;
+        border-radius: 8px;
+        font-weight: bold;
+        text-decoration: none;
+        transition: background-color 0.3s ease;
+      }
+      .back-to-templates-btn:hover {
+        background-color: #0056b3;
+      }
+      /* Hiding the heart icon on this page */
+      .favorite-btn {
+        display: none !important;
+      }
+      /* New style for the remove button */
+      .remove-btn {
+        display: inline-block;
+        margin-top: 10px;
+        padding: 8px 14px;
+        border: none;
+        border-radius: 20px;
+        background: #ff4d6d;
+        color: white;
+        font-weight: bold;
+        cursor: pointer;
+        text-align: center;
+        text-decoration: none;
+        position: relative; /* To position it correctly with the button */
+        left: 5px;
+        transition: color 0.3s ease, background-color 0.3s ease;
+      }
+      .remove-btn:hover {
+        background-color: #ff2c4f;
+      }
+      .template-actions {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-top: 10px;
+      }
+
+      /* Responsive adjustments */
+      @media (max-width: 768px) {
+        .saved-templates-header {
+          flex-direction: column;
+          align-items: center;
+          text-align: center;
+          gap: 10px;
+        }
+        .back-to-templates-btn {
+          position: static;
+          transform: none;
+        }
+        .templates-grid {
+          grid-template-columns: 1fr;
+        }
+      }
     </style>
   </head>
   <body>
-    <header>
-      <h1>⭐ Saved Templates</h1>
-      <a href="templates.html" class="template-btn">← Back to Templates</a>
-    </header>
+    <nav class="navbar scroll-fade">
+      <div class="nav-left">
+        <a href="index.html" class="logo-link">
+          <img src="images/logo.png" alt="AnimateItNow Logo" class="logo" />
+          <span class="site-name">Animate It Now</span>
+        </a>
+      </div>
 
-    <div class="container">
-      <div id="favorites-container" class="templates-grid"></div>
-      <p id="no-favorites" class="no-favorites" style="display: none">
-        You haven’t saved any templates yet.
-      </p>
-    </div>
+      <div class="nav-right">
+        <ul class="nav-links">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="editor.html" target="_blank">Editor</a></li>
+          <li><a href="templates.html">Templates</a></li>
+          <li>
+            <a href="playground.html" style="white-space: nowrap"
+              >Hover-Effects</a
+            >
+          </li>
+          <li><a href="contributors.html">Contributors</a></li>
+          <li><a href="contact.html">Contact</a></li>
+          <li><a href="leaderboard.html">Leaderboard</a></li>
+          <li>
+            <label class="switch" title="Toggle Snake Cursor">
+              <input type="checkbox" id="cursorToggle" />
+              <span class="slider round"></span>
+            </label>
+          </li>
+          <li>
+            <a
+              href="https://github.com/itsAnimation/AnimateItNow"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="GitHub Repo"
+              class="github-icon"
+            >
+              <svg
+                viewBox="0 0 16 16"
+                width="24"
+                height="24"
+                fill="currentColor"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"
+                />
+              </svg>
+            </a>
+          </li>
+          <li>
+            <button id="theme-toggle" aria-label="Toggle Theme">
+              <i data-lucide="moon"></i>
+            </button>
+          </li>
+        </ul>
+      </div>
+    </nav>
 
+    <main class="templates-main" id="container">
+      <div class="saved-templates-header">
+        <h1>Saved Templates</h1>
+        <a href="templates.html" class="back-to-templates-btn"
+          >Back to Templates</a
+        >
+      </div>
+      <div class="container">
+        <div id="favorites-container" class="templates-grid"></div>
+        <p id="no-favorites" class="no-favorites" style="display: none">
+          You haven’t saved any templates yet.
+        </p>
+      </div>
+    </main>
+    <footer class="footer scroll-fade">
+      <div class="footer-content">
+        <div class="footer-left">
+          <h2>AnimateItNow</h2>
+          <p>Creating impactful web animations and templates for everyone.</p>
+        </div>
+        <div class="footer-right">
+          <h4>Connect With Us</h4>
+          <ul>
+            <li>
+              <a
+                href="https://github.com/itsAnimation/AnimateItNow"
+                target="_blank"
+                rel="noopener noreferrer"
+                ><i class="fab fa-github fa-beat"></i> GitHub</a
+              >
+            </li>
+            <li>
+              <a
+                href="https://www.linkedin.com/in/anujshrivastava1/"
+                target="_blank"
+                rel="noopener noreferrer"
+                ><i class="fab fa-linkedin fa-beat"></i> LinkedIn</a
+              >
+            </li>
+            <li>
+              <a href="mailto:contact@animateitnow.com" rel="noopener noreferrer"
+                ><i class="fas fa-envelope fa-beat"></i> Email Us</a
+              >
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>
+          © 2025 AnimateItNow. Made with ❤️ by
+          <span class="highlight">Anuj</span> and Contributors.
+        </p>
+      </div>
+    </footer>
+
+    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="script.js"></script>
     <script>
       // Load Favorites from localStorage
-      const favorites = JSON.parse(localStorage.getItem("favorites")) || [];
+      let favorites = JSON.parse(localStorage.getItem("favorites")) || [];
       const container = document.getElementById("favorites-container");
       const noFavMessage = document.getElementById("no-favorites");
 
-      // Templates list (must match IDs used in templates.html)
+      // Templates object with preview HTML content
       const templates = {
         "login-form-glassmorphism": {
           title: "Login Form with Glassmorphism.",
           link: "templates/LoginFormGlassMorphism.html",
+          preview: `<div class="template-preview login-preview"><div class="page link"></div></div>`,
         },
         "login-page-ui": {
           title: "Login Page UI",
           link: "templates/login.html",
+          preview: `<div class="template-preview login-preview"></div>`,
         },
         "hover-button-effects": {
           title: "Hover Button Effects",
           link: "templates/button.html",
+          preview: `<div class="template-preview button-preview"></div>`,
         },
         loaders: {
           title: "Loaders",
           link: "templates/loader.html",
+          preview: `<div class="template-preview loader-preview"></div>`,
         },
         "text-animation-effects": {
           title: "Text Animation Effects",
           link: "templates/text_effects_anim.html",
+          preview: `<div class="template-preview text-preview"><h2 id="textTarget"></h2></div>`,
         },
         "popup-templates": {
           title: "Popup Templates",
           link: "templates/modal.html",
+          preview: `<div class="template-preview modal-preview"></div>`,
         },
         "glassmorphism-profile-card": {
           title: "Glassmorphism profile card",
           link: "templates/glassmorphism.html",
+          preview: `<div class="template-preview modal-preview"></div>`,
         },
         "code-playground": {
           title: "Code PlayGround",
           link: "templates/code_playground.html",
+          preview: `<div class="template-preview code-play-preview">Write Code</div>`,
         },
         "feature-cards-ui": {
           title: "Feature Cards UI",
           link: "templates/feature.html",
+          preview: `<div class="template-preview feature-preview"><div class="mini-card">Card1</div><div class="mini-card">Card2</div><div class="mini-card">Card3</div></div>`,
         },
         "hero-section-template": {
           title: "Hero Section Template",
           link: "templates/hero.html",
+          preview: `<div class="template-preview hero-preview"><div class="hero-image"></div><div class="hero-text-line"></div><div class="hero-text-line short"></div></div>`,
         },
         "animated-button": {
           title: "Animated Button",
           link: "templates/animated-btn.html",
+          preview: `<div class="template-preview button-preview"></div>`,
         },
         "animated-social-share-buttons": {
           title: "Animated Social Share Buttons",
           link: "templates/social-share-buttons.html",
+          preview: `<div class="template-preview social-share-preview"><i class="fab fa-facebook-f social-icon-preview"></i><i class="fab fa-twitter social-icon-preview"></i><i class="fab fa-instagram social-icon-preview"></i></div>`,
         },
         "tooltip-ui-component": {
           title: "Tooltip UI Component",
           link: "templates/tooltip.html",
+          preview: `<div class="template-preview"><button class="tooltip" data-tooltip="I’m a tooltip!">Hover</button></div>`,
         },
         "responsive-card-carousel": {
           title: "Responsive Card Carousel",
           link: "templates/carousel.html",
+          preview: `<div class="template-preview carousel-preview"><div class="mini-card"></div><div class="mini-card"></div><div class="mini-card"></div></div>`,
         },
         "animated-toggles": {
           title: "Animated Toggles",
           link: "templates/toggles-and-checkboxes.html",
+          preview: `<div class="template-preview toggles-preview"><div class="mini-toggle off"><div class="mini-handle"></div></div><div class="mini-toggle on"><div class="mini-handle"></div></div></div>`,
         },
         "neumorphic-button-effects": {
           title: "Neumorphic Button Effects",
           link: "templates/neumorphic.html",
+          preview: `<div class="template-preview neumorphic-preview"></div>`,
         },
         "navbar-variants": {
           title: "Navbar Variants",
           link: "templates/navbar.html",
+          preview: `<div class="template-preview navbar-preview"><div class="navbar-line logo"></div><div class="navbar-line link"></div><div class="navbar-line link short"></div></div>`,
         },
         "display-properties": {
           title: "Display Properties",
           link: "templates/display.html",
+          preview: `<div class="template-preview display-preview"><div class="display-box box1"></div><div class="display-box box2"></div><div class="display-box box3"></div></div>`,
         },
         "3d-card-hover-effects": {
           title: "3D Card Hover Effects",
           link: "templates/CardHoverEffects.html",
+          preview: `<div class="template-preview navbar-preview"><div class="navbar-line link"></div></div>`,
         },
         "404-page-not-found": {
           title: "404 Page not found",
           link: "templates/page_not_found_template.html",
+          preview: `<div class="template-preview 404-preview"><div class="page link"></div></div>`,
         },
         "contact-us-template": {
           title: "Contact Us Template",
           link: "templates/contact.html",
+          preview: `<div class="template-preview navbar-preview"><div class="fas fa-envelope" style="font-size: 40px; color: white;"></div></div>`,
         },
         "accordian-template": {
           title: "Accordian Template",
           link: "templates/accordian.html",
+          preview: `<div class="template-preview 404-preview"><div class="page link"></div></div>`,
         },
       };
 
-      // If no favorites → show message
-      if (favorites.length === 0) {
-        noFavMessage.style.display = "block";
-      } else {
-        favorites.forEach((id) => {
-          if (templates[id]) {
-            const card = document.createElement("a");
-            card.classList.add("template-card");
-            card.href = templates[id].link;
-            card.innerHTML = `
-            <h2>${templates[id].title}</h2>
-            <button class="template-btn">View Template</button>
-            `;
-            container.appendChild(card);
-          }
+      // Function to render favorite cards
+      function renderFavoriteCards() {
+        container.innerHTML = "";
+        if (favorites.length === 0) {
+          noFavMessage.style.display = "block";
+        } else {
+          noFavMessage.style.display = "none";
+          favorites.forEach((id) => {
+            if (templates[id]) {
+              const card = document.createElement("a");
+              card.classList.add("template-card");
+              card.href = templates[id].link;
+              card.setAttribute("data-id", id);
+              card.innerHTML = `
+                <h2>${templates[id].title}</h2>
+                ${templates[id].preview}
+                <div class="template-actions">
+                  <a class="template-btn" href="${templates[id].link}">View Template</a>
+                  <button class="remove-btn" data-id="${id}">Remove</button>
+                </div>
+              `;
+              container.appendChild(card);
+            }
+          });
+          attachEventListeners();
+        }
+      }
+
+      function attachEventListeners() {
+        // Event listener for the remove button
+        document.querySelectorAll(".remove-btn").forEach((button) => {
+          button.addEventListener("click", (e) => {
+            e.preventDefault();
+            const templateId = button.getAttribute("data-id");
+            favorites = favorites.filter((id) => id !== templateId);
+            localStorage.setItem("favorites", JSON.stringify(favorites));
+            renderFavoriteCards(); // Re-render the cards after removal
+          });
         });
       }
+
+      // Initial render
+      renderFavoriteCards();
+
+      // =============================
+      // Theme Toggle Functionality
+      // =============================
+      const themeToggle = document.getElementById("theme-toggle");
+      const body = document.body;
+
+      function setTheme(isDark) {
+        const newIcon = isDark ? "sun" : "moon";
+        body.classList.toggle("dark", isDark);
+        localStorage.setItem("theme", isDark ? "dark" : "light");
+        if (themeToggle) {
+          themeToggle.innerHTML = `<i data-lucide="${newIcon}"></i>`;
+          lucide.createIcons();
+        }
+      }
+      const savedTheme = localStorage.getItem("theme");
+      const prefersDark =
+        window.matchMedia &&
+        window.matchMedia("(prefers-color-scheme: dark)").matches;
+      setTheme(savedTheme === "dark" || (savedTheme === null && prefersDark));
+      themeToggle?.addEventListener("click", () => {
+        setTheme(!body.classList.contains("dark"));
+      });
+      lucide.createIcons();
     </script>
   </body>
 </html>

--- a/saved-templates.html
+++ b/saved-templates.html
@@ -133,7 +133,7 @@
         padding: 8px 14px;
         border: none;
         border-radius: 8px;
-        background: #0ff;
+        /* background: #0ff; */
         color: #000;
         font-weight: bold;
         cursor: pointer;
@@ -179,7 +179,7 @@
         top: 50%;
         transform: translateY(-50%);
         padding: 8px 16px;
-        background-color: #007bff;
+        background-color: #ff4d6d;
         color: white;
         border: none;
         border-radius: 8px;
@@ -188,7 +188,7 @@
         transition: background-color 0.3s ease;
       }
       .back-to-templates-btn:hover {
-        background-color: #0056b3;
+        background-color: #ff2c4f;
       }
       /* Hiding the heart icon on this page */
       .favorite-btn {
@@ -200,16 +200,16 @@
         margin-top: 10px;
         padding: 8px 14px;
         border: none;
-        border-radius: 20px;
+        border-radius: 8px; /* FIX: Changed from 20px to 8px */
         background: #ff4d6d;
         color: white;
         font-weight: bold;
         cursor: pointer;
         text-align: center;
         text-decoration: none;
-        position: relative; /* To position it correctly with the button */
-        left: 5px;
-        transition: color 0.3s ease, background-color 0.3s ease;
+        transition: background-color 0.3s ease;
+        margin-left: 5px;
+
       }
       .remove-btn:hover {
         background-color: #ff2c4f;
@@ -236,6 +236,18 @@
         .templates-grid {
           grid-template-columns: 1fr;
         }
+      }
+      /* New style for the template title on saved page for consistency */
+      .templates-main h1 {
+        background: linear-gradient(
+          to right,
+          #67e8f9,
+          #3b82f6
+        ); /*bright neon cyan-blue */
+        -webkit-background-clip: text;
+        background-clip: text;
+        -webkit-text-fill-color: transparent;
+        text-shadow: 0 2px 10px rgba(56, 189, 248, 0.4);
       }
     </style>
   </head>

--- a/templates.html
+++ b/templates.html
@@ -530,6 +530,22 @@
         margin-top: 1rem;
         font-weight: bold;
       }
+      .favorite-btn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: transparent;
+  border: none;
+  font-size: 1.4rem;
+  cursor: pointer;
+  color: #bbb;
+  transition: color 0.3s ease;
+}
+
+.favorite-btn.active {
+  color: #ff4d6d;
+}
+
 
       /* end for game animation */
     </style>
@@ -630,6 +646,9 @@
       <section class="templates-grid">
         <a class="template-card" href="templates/LoginFormGlassMorphism.html">
           <h2>Login Form with Glassmorphism.</h2>
+          <button class="favorite-btn" title="Add to Favorites">
+  <i class="fas fa-heart"></i>
+</button>
           <div class="template-preview login-preview">
             <div class="page link"></div>
           </div>
@@ -968,6 +987,37 @@
         setTimeout(typeLoop, isDelete ? speed / 2 : speed);
       }
       typeLoop(); // start animation
+
+      // =============================
+// Favorites Functionality
+// =============================
+let favorites = JSON.parse(localStorage.getItem("favorites")) || [];
+
+document.querySelectorAll(".favorite-btn").forEach(button => {
+  const card = button.closest(".template-card");
+  const templateId = card.getAttribute("data-id");
+
+  // Initial state
+  if (favorites.includes(templateId)) {
+    button.classList.add("active");
+  }
+
+  // Toggle on click
+  button.addEventListener("click", (e) => {
+    e.preventDefault(); // prevent <a> from redirecting immediately
+
+    if (favorites.includes(templateId)) {
+      favorites = favorites.filter(id => id !== templateId);
+      button.classList.remove("active");
+    } else {
+      favorites.push(templateId);
+      button.classList.add("active");
+    }
+
+    localStorage.setItem("favorites", JSON.stringify(favorites));
+  });
+});
+
     </script>
   </body>
 </html>

--- a/templates.html
+++ b/templates.html
@@ -9,7 +9,6 @@
       content="A comprehensive collection of CSS animation templates and effects for web developers"
     />
 
-    <!-- PWA Meta Tags -->
     <meta name="theme-color" content="#ff6b6b" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
@@ -20,10 +19,8 @@
     />
     <meta name="msapplication-TileColor" content="#ff6b6b" />
 
-    <!-- PWA Manifest -->
     <link rel="manifest" href="manifest.json" />
 
-    <!-- PWA Icons -->
     <link
       rel="icon"
       type="image/png"
@@ -73,7 +70,6 @@
       href="images/icons/icon-512x512.png"
     />
 
-    <!-- Apple Touch Icons -->
     <link
       rel="apple-touch-icon"
       sizes="152x152"
@@ -85,7 +81,6 @@
       href="images/icons/icon-192x192.png"
     />
 
-    <!-- Fallback icon -->
     <link rel="icon" type="image/png" href="images/logo.png" />
     <link rel="stylesheet" href="styles.css" />
     <link
@@ -98,7 +93,7 @@
     />
 
     <style>
-      /*  Removed conflicting navbar CSS, relying on styles.css */
+      /*  Removed conflicting navbar CSS, relying on styles.css */
       .navbar {
         display: flex;
         flex-direction: row;
@@ -115,7 +110,7 @@
         text-decoration: none;
       }
       /* 🌒 DARK MODE GLOBAL TEXT FIXES */
-      /*  Changed 'dark-theme' to 'dark' to match script.js and other pages */
+      /*  Changed 'dark-theme' to 'dark' to match script.js and other pages */
       body.dark {
         background-color: #121212;
         color: #f5f5f5;
@@ -125,11 +120,7 @@
       }
       /* ✅ Heading fix */
       body.dark .templates-main h1 {
-        background: linear-gradient(
-          to right,
-          #67e8f9,
-          #3b82f6
-        ); /*bright neon cyan-blue */
+        background: linear-gradient(to right, #67e8f9, #3b82f6); /*bright neon cyan-blue */
         -webkit-background-clip: text;
         background-clip: text;
         -webkit-text-fill-color: transparent;
@@ -235,7 +226,7 @@
         box-sizing: border-box;
       }
       /* Dark mode support */
-      /*  Changed 'dark-theme' to 'dark' */
+      /*  Changed 'dark-theme' to 'dark' */
       body.dark .template-preview {
         background-color: #2a2a2a;
         box-shadow: 0 2px 6px rgb(255 255 255 / 0.1);
@@ -321,23 +312,23 @@
       }
       /* Make the link a flex container to align items */
       .logo-link {
-        display: flex;          /* Aligns logo and text horizontally */
-        align-items: center;   /* Centers them vertically */
-        gap: 10px;            /* Adds space between logo and text */
+        display: flex; /* Aligns logo and text horizontally */
+        align-items: center; /* Centers them vertically */
+        gap: 10px; /* Adds space between logo and text */
         text-decoration: none; /* Removes underline */
-        color: inherit;       /* Inherits text color (if needed) */
+        color: inherit; /* Inherits text color (if needed) */
       }
 
       /* Ensure the logo image stays aligned */
       .logo-link img.logo {
-        height: 40px;         /* Adjust as needed */
-        width: auto;          /* Maintains aspect ratio */
+        height: 40px; /* Adjust as needed */
+        width: auto; /* Maintains aspect ratio */
       }
 
       /* Style the text (optional) */
       .site-name {
-        font-size: 1.2rem;    /* Adjust size */
-        font-weight: bold;    /* Optional: Bold text */
+        font-size: 1.2rem; /* Adjust size */
+        font-weight: bold; /* Optional: Bold text */
         pointer-events: none; /* Ensures clicks pass to parent <a> */
       }
 
@@ -418,7 +409,7 @@
         box-shadow: 0 2px 6px rgba(255, 255, 255, 0.1);
       }
 
-      /*  start for game animation */
+      /*  start for game animation */
 
       h1 {
         text-align: center;
@@ -531,22 +522,50 @@
         font-weight: bold;
       }
       .favorite-btn {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  background: transparent;
-  border: none;
-  font-size: 1.4rem;
-  cursor: pointer;
-  color: #bbb;
-  transition: color 0.3s ease;
-}
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        background: transparent;
+        border: none;
+        font-size: 1.4rem;
+        cursor: pointer;
+        color: #bbb;
+        transition: color 0.3s ease;
+      }
 
-.favorite-btn.active {
-  color: #ff4d6d;
-}
+      .favorite-btn.active {
+        color: #ff4d6d;
+      }
+      /* New CSS for the button and container */
+      .templates-header {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: 20px;
+        position: relative;
+      }
 
+      .templates-header h1 {
+        margin: 0;
+      }
 
+      .saved-templates-btn {
+        position: absolute;
+        right: 0;
+        top: 50%;
+        transform: translateY(-50%);
+        padding: 8px 16px;
+        background-color: #ff4d6d;
+        color: white;
+        border: none;
+        border-radius: 8px;
+        font-weight: bold;
+        text-decoration: none;
+        transition: background-color 0.3s ease;
+      }
+      .saved-templates-btn:hover {
+        background-color: #ff2c4f;
+      }
       /* end for game animation */
     </style>
   </head>
@@ -565,18 +584,20 @@
           <li><a href="about.html">About</a></li>
           <li><a href="editor.html" target="_blank">Editor</a></li>
           <li><a href="templates.html" class="active">Templates</a></li>
-          <li><a href="playground.html" style="white-space: nowrap">Hover-Effects</a></li>
+          <li>
+            <a href="playground.html" style="white-space: nowrap"
+              >Hover-Effects</a
+            >
+          </li>
           <li><a href="contributors.html">Contributors</a></li>
           <li><a href="contact.html">Contact</a></li>
           <li><a href="leaderboard.html">Leaderboard</a></li>
-          <!-- cursor toggle switch -->
           <li>
             <label class="switch" title="Toggle Snake Cursor">
               <input type="checkbox" id="cursorToggle" />
               <span class="slider round"></span>
             </label>
           </li>
-          <!-- github icon -->
           <li>
             <a
               href="https://github.com/itsAnimation/AnimateItNow"
@@ -593,18 +614,7 @@
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 
-                7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49
-                -2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13
-                -.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82
-               .72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07
-              -1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15
-              -.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82
-              .64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27
-              1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12
-              .51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95
-              .29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2
-              0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"
+                  d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"
                 />
               </svg>
             </a>
@@ -618,7 +628,12 @@
       </div>
     </nav>
     <main class="templates-main">
-      <h1>Templates Gallery</h1>
+      <div class="templates-header">
+        <h1>Templates Gallery</h1>
+        <a href="saved-templates.html" class="saved-templates-btn"
+          >View Saved Templates</a
+        >
+      </div>
       <div
         style="display: flex; justify-content: center; margin-bottom: 1.5rem"
       >
@@ -640,48 +655,65 @@
           aria-label="Search templates"
         />
       </div>
-       <div class="no-results">
-  No Templates Found.
-</div>
+      <div class="no-results">No Templates Found.</div>
       <section class="templates-grid">
-        <a class="template-card" href="templates/LoginFormGlassMorphism.html">
+        <a
+          class="template-card"
+          href="templates/LoginFormGlassMorphism.html"
+          data-id="login-form-glassmorphism"
+        >
           <h2>Login Form with Glassmorphism.</h2>
           <button class="favorite-btn" title="Add to Favorites">
-  <i class="fas fa-heart"></i>
-</button>
+            <i class="fas fa-heart"></i>
+          </button>
           <div class="template-preview login-preview">
             <div class="page link"></div>
           </div>
           <button class="template-btn">View Template</button>
         </a>
-        <a class="template-card" href="templates/login.html">
+        <a
+          class="template-card"
+          href="templates/login.html"
+          data-id="login-page-ui"
+        >
           <h2>Login Page UI</h2>
-           <button class="favorite-btn" title="Add to Favorites">
+          <button class="favorite-btn" title="Add to Favorites">
             <i class="fas fa-heart"></i>
           </button>
           <div class="template-preview login-preview"></div>
           <button class="template-btn">View Template</button>
         </a>
-        <a class="template-card" href="templates/button.html">
+        <a
+          class="template-card"
+          href="templates/button.html"
+          data-id="hover-button-effects"
+        >
           <h2>Hover Button Effects</h2>
-           <button class="favorite-btn" title="Add to Favorites">
+          <button class="favorite-btn" title="Add to Favorites">
             <i class="fas fa-heart"></i>
           </button>
           <div class="template-preview button-preview"></div>
           <button class="template-btn">View Template</button>
         </a>
-        <a class="template-card" href="templates/loader.html">
+        <a
+          class="template-card"
+          href="templates/loader.html"
+          data-id="loaders"
+        >
           <h2>Loaders</h2>
-           <button class="favorite-btn" title="Add to Favorites">
+          <button class="favorite-btn" title="Add to Favorites">
             <i class="fas fa-heart"></i>
           </button>
           <div class="template-preview loader-preview"></div>
           <button class="template-btn">View Template</button>
         </a>
-        <!-- aading texts effects -->
-        <a class="template-card" href="templates/text_effects_anim.html">
+        <a
+          class="template-card"
+          href="templates/text_effects_anim.html"
+          data-id="text-animation-effects"
+        >
           <h2>Text Animation Effects</h2>
-           <button class="favorite-btn" title="Add to Favorites">
+          <button class="favorite-btn" title="Add to Favorites">
             <i class="fas fa-heart"></i>
           </button>
           <div class="template-preview text-preview">
@@ -689,35 +721,42 @@
           </div>
           <button class="template-btn">View Template</button>
         </a>
-        <a class="template-card" href="templates/modal.html">
+        <a class="template-card" href="templates/modal.html" data-id="popup-templates">
           <h2>Popup Templates</h2>
-           <button class="favorite-btn" title="Add to Favorites">
+          <button class="favorite-btn" title="Add to Favorites">
             <i class="fas fa-heart"></i>
           </button>
           <div class="template-preview modal-preview"></div>
           <button class="template-btn">View Template</button>
         </a>
-        <a class="template-card" href="templates/glassmorphism.html">
+        <a
+          class="template-card"
+          href="templates/glassmorphism.html"
+          data-id="glassmorphism-profile-card"
+        >
           <h2>Glassmorphism profile card</h2>
-           <button class="favorite-btn" title="Add to Favorites">
+          <button class="favorite-btn" title="Add to Favorites">
             <i class="fas fa-heart"></i>
           </button>
           <div class="template-preview modal-preview"></div>
           <button class="template-btn">View Template</button>
         </a>
-        <!-- adding code Playground -->
-        <a class="template-card" href="templates/code_playground.html">
+        <a
+          class="template-card"
+          href="templates/code_playground.html"
+          data-id="code-playground"
+        >
           <h2>Code PlayGround</h2>
-           <button class="favorite-btn" title="Add to Favorites">
+          <button class="favorite-btn" title="Add to Favorites">
             <i class="fas fa-heart"></i>
           </button>
           <div class="template-preview code-play-preview">Write Code</div>
           <button class="template-btn">View Template</button>
         </a>
 
-        <a class="template-card" href="templates/feature.html">
+        <a class="template-card" href="templates/feature.html" data-id="feature-cards-ui">
           <h2>Feature Cards UI</h2>
-           <button class="favorite-btn" title="Add to Favorites">
+          <button class="favorite-btn" title="Add to Favorites">
             <i class="fas fa-heart"></i>
           </button>
           <div class="template-preview feature-preview">
@@ -727,9 +766,13 @@
           </div>
           <button class="template-btn">View Template</button>
         </a>
-        <a class="template-card" href="templates/hero.html">
+        <a
+          class="template-card"
+          href="templates/hero.html"
+          data-id="hero-section-template"
+        >
           <h2>Hero Section Template</h2>
-           <button class="favorite-btn" title="Add to Favorites">
+          <button class="favorite-btn" title="Add to Favorites">
             <i class="fas fa-heart"></i>
           </button>
           <div class="template-preview hero-preview">
@@ -739,9 +782,12 @@
           </div>
           <button class="template-btn">View Template</button>
         </a>
-        <article class="template-card">
+        <article
+          class="template-card"
+          data-id="animated-button"
+        >
           <h2>Animated Button</h2>
-           <button class="favorite-btn" title="Add to Favorites">
+          <button class="favorite-btn" title="Add to Favorites">
             <i class="fas fa-heart"></i>
           </button>
           <div class="template-preview button-preview"></div>
@@ -749,9 +795,13 @@
             >View Template</a
           >
         </article>
-        <a class="template-card" href="templates/social-share-buttons.html">
+        <a
+          class="template-card"
+          href="templates/social-share-buttons.html"
+          data-id="animated-social-share-buttons"
+        >
           <h2>Animated Social Share Buttons</h2>
-           <button class="favorite-btn" title="Add to Favorites">
+          <button class="favorite-btn" title="Add to Favorites">
             <i class="fas fa-heart"></i>
           </button>
           <div class="template-preview social-share-preview">
@@ -761,10 +811,9 @@
           </div>
           <button class="template-btn">View Template</button>
         </a>
-        <!-- CORRECTED TOOLTIP COMPONENT -->
-        <a class="template-card" href="templates/tooltip.html">
+        <a class="template-card" href="templates/tooltip.html" data-id="tooltip-ui-component">
           <h2>Tooltip UI Component</h2>
-           <button class="favorite-btn" title="Add to Favorites">
+          <button class="favorite-btn" title="Add to Favorites">
             <i class="fas fa-heart"></i>
           </button>
           <div class="template-preview">
@@ -772,10 +821,13 @@
           </div>
           <span class="template-btn">View Template</span>
         </a>
-        <!-- Responsive Card Carousel -->
-        <a class="template-card" href="templates/carousel.html">
+        <a
+          class="template-card"
+          href="templates/carousel.html"
+          data-id="responsive-card-carousel"
+        >
           <h2>Responsive Card Carousel</h2>
-           <button class="favorite-btn" title="Add to Favorites">
+          <button class="favorite-btn" title="Add to Favorites">
             <i class="fas fa-heart"></i>
           </button>
           <div class="template-preview carousel-preview">
@@ -785,10 +837,13 @@
           </div>
           <span class="template-btn">View Template</span>
         </a>
-        <!-- NEWLY ADDED ANIMATED TOGGLES CARD -->
-        <a class="template-card" href="templates/toggles-and-checkboxes.html">
+        <a
+          class="template-card"
+          href="templates/toggles-and-checkboxes.html"
+          data-id="animated-toggles"
+        >
           <h2>Animated Toggles</h2>
-           <button class="favorite-btn" title="Add to Favorites">
+          <button class="favorite-btn" title="Add to Favorites">
             <i class="fas fa-heart"></i>
           </button>
           <div class="template-preview toggles-preview">
@@ -801,17 +856,21 @@
           </div>
           <button class="template-btn">View Template</button>
         </a>
-        <a class="template-card" href="templates/neumorphic.html">
+        <a
+          class="template-card"
+          href="templates/neumorphic.html"
+          data-id="neumorphic-button-effects"
+        >
           <h2>Neumorphic Button Effects</h2>
-           <button class="favorite-btn" title="Add to Favorites">
+          <button class="favorite-btn" title="Add to Favorites">
             <i class="fas fa-heart"></i>
           </button>
           <div class="template-preview neumorphic-preview"></div>
           <button class="template-btn">View Template</button>
         </a>
-        <a class="template-card" href="templates/navbar.html">
+        <a class="template-card" href="templates/navbar.html" data-id="navbar-variants">
           <h2>Navbar Variants</h2>
-           <button class="favorite-btn" title="Add to Favorites">
+          <button class="favorite-btn" title="Add to Favorites">
             <i class="fas fa-heart"></i>
           </button>
           <div class="template-preview navbar-preview">
@@ -821,9 +880,13 @@
           </div>
           <button class="template-btn">View Template</button>
         </a>
-        <a class="template-card" href="templates/display.html">
+        <a
+          class="template-card"
+          href="templates/display.html"
+          data-id="display-properties"
+        >
           <h2>Display Properties</h2>
-           <button class="favorite-btn" title="Add to Favorites">
+          <button class="favorite-btn" title="Add to Favorites">
             <i class="fas fa-heart"></i>
           </button>
           <div class="template-preview display-preview">
@@ -833,9 +896,13 @@
           </div>
           <button class="template-btn">View Template</button>
         </a>
-        <a class="template-card" href="templates/CardHoverEffects.html">
+        <a
+          class="template-card"
+          href="templates/CardHoverEffects.html"
+          data-id="3d-card-hover-effects"
+        >
           <h2>3D Card Hover Effects</h2>
-           <button class="favorite-btn" title="Add to Favorites">
+          <button class="favorite-btn" title="Add to Favorites">
             <i class="fas fa-heart"></i>
           </button>
           <div class="template-preview navbar-preview">
@@ -843,9 +910,13 @@
           </div>
           <button class="template-btn">View Template</button>
         </a>
-        <a class="template-card" href="templates/page_not_found_template.html">
+        <a
+          class="template-card"
+          href="templates/page_not_found_template.html"
+          data-id="404-page-not-found"
+        >
           <h2>404 Page not found</h2>
-           <button class="favorite-btn" title="Add to Favorites">
+          <button class="favorite-btn" title="Add to Favorites">
             <i class="fas fa-heart"></i>
           </button>
           <div class="template-preview 404-preview">
@@ -853,19 +924,30 @@
           </div>
           <button class="template-btn">View Template</button>
         </a>
-        <a class="template-card" href="templates/contact.html">
-        <h2>Contact Us Template</h2>
-         <button class="favorite-btn" title="Add to Favorites">
+        <a
+          class="template-card"
+          href="templates/contact.html"
+          data-id="contact-us-template"
+        >
+          <h2>Contact Us Template</h2>
+          <button class="favorite-btn" title="Add to Favorites">
             <i class="fas fa-heart"></i>
           </button>
-        <div class="template-preview navbar-preview">
-          <div class="fas fa-envelope" style="font-size: 40px; color: white;"></div>
-        </div>
-        <button class="template-btn">View Template</button>
-      </a>
-        <a class="template-card" href="templates/accordian.html">
+          <div class="template-preview navbar-preview">
+            <div
+              class="fas fa-envelope"
+              style="font-size: 40px; color: white"
+            ></div>
+          </div>
+          <button class="template-btn">View Template</button>
+        </a>
+        <a
+          class="template-card"
+          href="templates/accordian.html"
+          data-id="accordian-template"
+        >
           <h2>Accordian Template</h2>
-           <button class="favorite-btn" title="Add to Favorites">
+          <button class="favorite-btn" title="Add to Favorites">
             <i class="fas fa-heart"></i>
           </button>
           <div class="template-preview 404-preview">
@@ -922,13 +1004,10 @@
         </div>
       </footer>
     </div>
-    <!--  Removed the hardcoded cursor-snake div. script.js creates it dynamically. -->
-    <!-- <div id="cursor-snake"></div> -->
     <script src="https://unpkg.com/lucide@latest"></script>
-    <!--  Added link to your shared script.js -->
     <script src="script.js"></script>
     <script>
-      //  This script now ONLY contains functionality specific to templates.html
+      //  This script now ONLY contains functionality specific to templates.html
       // Theme toggle and cursor logic are handled by script.js
       // Theme toggle functionality
       const themeToggle = document.getElementById("theme-toggle");
@@ -997,10 +1076,8 @@
         });
 
         if (noResultsMsg) {
-
-          noResultsMsg.style.display = visibleCount === 0 ? 'block' : 'none';
+          noResultsMsg.style.display = visibleCount === 0 ? "block" : "none";
         }
-     
       }
       searchBar.addEventListener("input", filterTemplates);
 
@@ -1052,35 +1129,34 @@
       typeLoop(); // start animation
 
       // =============================
-// Favorites Functionality
-// =============================
-let favorites = JSON.parse(localStorage.getItem("favorites")) || [];
+      // Favorites Functionality
+      // =============================
+      let favorites = JSON.parse(localStorage.getItem("favorites")) || [];
 
-document.querySelectorAll(".favorite-btn").forEach(button => {
-  const card = button.closest(".template-card");
-  const templateId = card.getAttribute("data-id");
+      document.querySelectorAll(".favorite-btn").forEach((button) => {
+        const card = button.closest(".template-card");
+        const templateId = card.getAttribute("data-id");
 
-  // Initial state
-  if (favorites.includes(templateId)) {
-    button.classList.add("active");
-  }
+        // Initial state
+        if (favorites.includes(templateId)) {
+          button.classList.add("active");
+        }
 
-  // Toggle on click
-  button.addEventListener("click", (e) => {
-    e.preventDefault(); // prevent <a> from redirecting immediately
+        // Toggle on click
+        button.addEventListener("click", (e) => {
+          e.preventDefault(); // prevent <a> from redirecting immediately
 
-    if (favorites.includes(templateId)) {
-      favorites = favorites.filter(id => id !== templateId);
-      button.classList.remove("active");
-    } else {
-      favorites.push(templateId);
-      button.classList.add("active");
-    }
+          if (favorites.includes(templateId)) {
+            favorites = favorites.filter((id) => id !== templateId);
+            button.classList.remove("active");
+          } else {
+            favorites.push(templateId);
+            button.classList.add("active");
+          }
 
-    localStorage.setItem("favorites", JSON.stringify(favorites));
-  });
-});
-
+          localStorage.setItem("favorites", JSON.stringify(favorites));
+        });
+      });
     </script>
   </body>
 </html>

--- a/templates.html
+++ b/templates.html
@@ -656,22 +656,34 @@
         </a>
         <a class="template-card" href="templates/login.html">
           <h2>Login Page UI</h2>
+           <button class="favorite-btn" title="Add to Favorites">
+            <i class="fas fa-heart"></i>
+          </button>
           <div class="template-preview login-preview"></div>
           <button class="template-btn">View Template</button>
         </a>
         <a class="template-card" href="templates/button.html">
           <h2>Hover Button Effects</h2>
+           <button class="favorite-btn" title="Add to Favorites">
+            <i class="fas fa-heart"></i>
+          </button>
           <div class="template-preview button-preview"></div>
           <button class="template-btn">View Template</button>
         </a>
         <a class="template-card" href="templates/loader.html">
           <h2>Loaders</h2>
+           <button class="favorite-btn" title="Add to Favorites">
+            <i class="fas fa-heart"></i>
+          </button>
           <div class="template-preview loader-preview"></div>
           <button class="template-btn">View Template</button>
         </a>
         <!-- aading texts effects -->
         <a class="template-card" href="templates/text_effects_anim.html">
           <h2>Text Animation Effects</h2>
+           <button class="favorite-btn" title="Add to Favorites">
+            <i class="fas fa-heart"></i>
+          </button>
           <div class="template-preview text-preview">
             <h2 id="textTarget"></h2>
           </div>
@@ -679,23 +691,35 @@
         </a>
         <a class="template-card" href="templates/modal.html">
           <h2>Popup Templates</h2>
+           <button class="favorite-btn" title="Add to Favorites">
+            <i class="fas fa-heart"></i>
+          </button>
           <div class="template-preview modal-preview"></div>
           <button class="template-btn">View Template</button>
         </a>
         <a class="template-card" href="templates/glassmorphism.html">
           <h2>Glassmorphism profile card</h2>
+           <button class="favorite-btn" title="Add to Favorites">
+            <i class="fas fa-heart"></i>
+          </button>
           <div class="template-preview modal-preview"></div>
           <button class="template-btn">View Template</button>
         </a>
         <!-- adding code Playground -->
         <a class="template-card" href="templates/code_playground.html">
           <h2>Code PlayGround</h2>
+           <button class="favorite-btn" title="Add to Favorites">
+            <i class="fas fa-heart"></i>
+          </button>
           <div class="template-preview code-play-preview">Write Code</div>
           <button class="template-btn">View Template</button>
         </a>
 
         <a class="template-card" href="templates/feature.html">
           <h2>Feature Cards UI</h2>
+           <button class="favorite-btn" title="Add to Favorites">
+            <i class="fas fa-heart"></i>
+          </button>
           <div class="template-preview feature-preview">
             <div class="mini-card">Card1</div>
             <div class="mini-card">Card2</div>
@@ -705,6 +729,9 @@
         </a>
         <a class="template-card" href="templates/hero.html">
           <h2>Hero Section Template</h2>
+           <button class="favorite-btn" title="Add to Favorites">
+            <i class="fas fa-heart"></i>
+          </button>
           <div class="template-preview hero-preview">
             <div class="hero-image"></div>
             <div class="hero-text-line"></div>
@@ -714,6 +741,9 @@
         </a>
         <article class="template-card">
           <h2>Animated Button</h2>
+           <button class="favorite-btn" title="Add to Favorites">
+            <i class="fas fa-heart"></i>
+          </button>
           <div class="template-preview button-preview"></div>
           <a class="template-btn" href="templates/animated-btn.html"
             >View Template</a
@@ -721,6 +751,9 @@
         </article>
         <a class="template-card" href="templates/social-share-buttons.html">
           <h2>Animated Social Share Buttons</h2>
+           <button class="favorite-btn" title="Add to Favorites">
+            <i class="fas fa-heart"></i>
+          </button>
           <div class="template-preview social-share-preview">
             <i class="fab fa-facebook-f social-icon-preview"></i>
             <i class="fab fa-twitter social-icon-preview"></i>
@@ -731,6 +764,9 @@
         <!-- CORRECTED TOOLTIP COMPONENT -->
         <a class="template-card" href="templates/tooltip.html">
           <h2>Tooltip UI Component</h2>
+           <button class="favorite-btn" title="Add to Favorites">
+            <i class="fas fa-heart"></i>
+          </button>
           <div class="template-preview">
             <button class="tooltip" data-tooltip="I’m a tooltip!">Hover</button>
           </div>
@@ -739,6 +775,9 @@
         <!-- Responsive Card Carousel -->
         <a class="template-card" href="templates/carousel.html">
           <h2>Responsive Card Carousel</h2>
+           <button class="favorite-btn" title="Add to Favorites">
+            <i class="fas fa-heart"></i>
+          </button>
           <div class="template-preview carousel-preview">
             <div class="mini-card"></div>
             <div class="mini-card"></div>
@@ -749,6 +788,9 @@
         <!-- NEWLY ADDED ANIMATED TOGGLES CARD -->
         <a class="template-card" href="templates/toggles-and-checkboxes.html">
           <h2>Animated Toggles</h2>
+           <button class="favorite-btn" title="Add to Favorites">
+            <i class="fas fa-heart"></i>
+          </button>
           <div class="template-preview toggles-preview">
             <div class="mini-toggle off">
               <div class="mini-handle"></div>
@@ -761,11 +803,17 @@
         </a>
         <a class="template-card" href="templates/neumorphic.html">
           <h2>Neumorphic Button Effects</h2>
+           <button class="favorite-btn" title="Add to Favorites">
+            <i class="fas fa-heart"></i>
+          </button>
           <div class="template-preview neumorphic-preview"></div>
           <button class="template-btn">View Template</button>
         </a>
         <a class="template-card" href="templates/navbar.html">
           <h2>Navbar Variants</h2>
+           <button class="favorite-btn" title="Add to Favorites">
+            <i class="fas fa-heart"></i>
+          </button>
           <div class="template-preview navbar-preview">
             <div class="navbar-line logo"></div>
             <div class="navbar-line link"></div>
@@ -775,6 +823,9 @@
         </a>
         <a class="template-card" href="templates/display.html">
           <h2>Display Properties</h2>
+           <button class="favorite-btn" title="Add to Favorites">
+            <i class="fas fa-heart"></i>
+          </button>
           <div class="template-preview display-preview">
             <div class="display-box box1"></div>
             <div class="display-box box2"></div>
@@ -784,6 +835,9 @@
         </a>
         <a class="template-card" href="templates/CardHoverEffects.html">
           <h2>3D Card Hover Effects</h2>
+           <button class="favorite-btn" title="Add to Favorites">
+            <i class="fas fa-heart"></i>
+          </button>
           <div class="template-preview navbar-preview">
             <div class="navbar-line link"></div>
           </div>
@@ -791,6 +845,9 @@
         </a>
         <a class="template-card" href="templates/page_not_found_template.html">
           <h2>404 Page not found</h2>
+           <button class="favorite-btn" title="Add to Favorites">
+            <i class="fas fa-heart"></i>
+          </button>
           <div class="template-preview 404-preview">
             <div class="page link"></div>
           </div>
@@ -798,6 +855,9 @@
         </a>
         <a class="template-card" href="templates/contact.html">
         <h2>Contact Us Template</h2>
+         <button class="favorite-btn" title="Add to Favorites">
+            <i class="fas fa-heart"></i>
+          </button>
         <div class="template-preview navbar-preview">
           <div class="fas fa-envelope" style="font-size: 40px; color: white;"></div>
         </div>
@@ -805,6 +865,9 @@
       </a>
         <a class="template-card" href="templates/accordian.html">
           <h2>Accordian Template</h2>
+           <button class="favorite-btn" title="Add to Favorites">
+            <i class="fas fa-heart"></i>
+          </button>
           <div class="template-preview 404-preview">
             <div class="page link"></div>
           </div>

--- a/templates.html
+++ b/templates.html
@@ -555,7 +555,7 @@
         top: 50%;
         transform: translateY(-50%);
         padding: 8px 16px;
-        background-color: #ff4d6d;
+        background-color: #007bff;
         color: white;
         border: none;
         border-radius: 8px;


### PR DESCRIPTION
📄 Description

This PR implements the Favorites / Save Templates feature. Users can now mark templates as favorites (❤️) and access them later in a dedicated Saved Templates section.

Fixes #1093

🛠️ Type of Change

New feature ✨

✅ Checklist

i) Added a Favorite button (❤️) to each template card.

ii) Implemented localStorage persistence so favorites remain after reload.

iii) Created a Saved Templates page (saved-templates.html) that displays only favorited templates.

iv) Added functionality to remove/unfavorite templates from saved list.

v) Tested across multiple templates for correct behavior.

vi) Code follows the project’s style guidelines.

vii) Linked the issue with Fixes #1093 

📸 Screenshots
Before
<img width="1919" height="962" alt="image" src="https://github.com/user-attachments/assets/26183bfe-cb2c-445c-89e4-36c5bc7dc570" />

(Templates page without favorite button)

After
<img width="1915" height="965" alt="image" src="https://github.com/user-attachments/assets/fc4e94bd-0b74-4353-ba5a-1687f9104654" />

(Templates page with favorite button and Saved Templates section)

<img width="1918" height="969" alt="image" src="https://github.com/user-attachments/assets/1e5e557f-4b86-4aeb-9c6f-6b62caa99a19" />
(A new Saved Templates page with remove button)

📚 Related Issues

Fixes #1093

🧠 Additional Context

i) This feature improves user experience by letting users curate their favorite templates.

ii) Future enhancements could include exporting saved templates or syncing favorites via GitHub login.