### PR TITLE
feat: add new hover effects (Magnetic 3D, Liquid Sheen, Depth Text); …

### DIFF
--- a/playground.html
+++ b/playground.html
@@ -106,6 +106,10 @@
             <div class="box Box-Shadow">Box-Shadow</div>
             <div class="box Background-Color">Background-Color</div>
             <div class="box Color">Color</div>
+            <div class="box hover-magnetic">Magnetic 3D</div>
+            <div class="box hover-liquid">Liquid Sheen</div>
+            
+            <div class="box hover-depth" data-text="Depth Text">Depth Text</div>
         </div>
     </section>
   </main>

--- a/styles.css
+++ b/styles.css
@@ -2820,6 +2820,99 @@ justify-content: center;
    animation: subtleGlow 4s ease-in-out infinite alternate;
    
 }
+.box:hover{ cursor: pointer; }
+
+/* New unique hover effects */
+.hover-magnetic {
+  position: relative;
+  perspective: 800px;
+  transform-style: preserve-3d;
+}
+.hover-magnetic:hover {
+  transform: translateY(-10px) rotateX(8deg) rotateY(-8deg) scale(1.06);
+  box-shadow: 0 18px 40px rgba(0, 255, 255, 0.25), 0 8px 18px rgba(0, 0, 0, 0.35);
+  border-color: rgba(0, 255, 255, 0.35);
+  color: #e6f9ff;
+}
+.hover-magnetic::after {
+  content: "";
+  position: absolute;
+  inset: -2px;
+  border-radius: inherit;
+  background: radial-gradient(120% 120% at 10% 10%, rgba(0, 255, 255, 0.45), transparent 60%),
+              radial-gradient(120% 120% at 90% 90%, rgba(99, 102, 241, 0.45), transparent 60%);
+  filter: blur(12px);
+  opacity: 0;
+  transition: opacity .3s ease;
+  z-index: -1;
+}
+.hover-magnetic:hover::after { opacity: 1; }
+
+.hover-liquid {
+  position: relative;
+  overflow: hidden;
+}
+.hover-liquid::before {
+  content: "";
+  position: absolute;
+  left: -150%;
+  top: -150%;
+  width: 300%;
+  height: 300%;
+  background: radial-gradient(circle at 30% 30%, rgba(255,255,255,0.35), transparent 25%),
+              radial-gradient(circle at 70% 70%, rgba(255,255,255,0.25), transparent 25%);
+  transform: rotate(0deg);
+  transition: transform .6s ease, left .6s ease, top .6s ease;
+}
+.hover-liquid:hover::before {
+  left: -50%;
+  top: -50%;
+  transform: rotate(25deg);
+}
+.hover-liquid::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -150%;
+  width: 120%;
+  height: 100%;
+  background: linear-gradient(115deg, transparent 40%, rgba(255,255,255,0.6) 50%, transparent 60%);
+  transform: skewX(-20deg);
+  opacity: 0.0;
+}
+.hover-liquid:hover::after {
+  animation: sheenSlide 0.9s ease forwards;
+}
+@keyframes sheenSlide {
+  0% { left: -160%; opacity: 0.0; }
+  30% { opacity: 0.5; }
+  100% { left: 140%; opacity: 0; }
+}
+
+.hover-scanline {}
+
+.hover-depth {
+  position: relative;
+}
+.hover-depth::after {
+  content: attr(data-text);
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  color: transparent;
+  text-shadow: 0 0 0 rgba(0,0,0,0);
+  transform: translateZ(0);
+  transition: text-shadow .35s ease, transform .35s ease, color .35s ease;
+}
+.hover-depth:hover {
+  transform: translateY(-6px) scale(1.03);
+}
+.hover-depth:hover::after {
+  color: rgba(255,255,255,0.9);
+  text-shadow: 0 3px 0 rgba(0,0,0,0.18), 0 10px 24px rgba(0,0,0,0.35);
+  transform: translateZ(40px);
+}
 /* Glow animation in light mode */
 @keyframes subtleGlow {
   0% {


### PR DESCRIPTION
# 🚀 Pull Request: Add 3 new hover effects and remove scanline demo

## 📄 Description
This PR adds three new, distinct hover effects to the Hover-Effects page and removes the scanline demo per feedback.

- Added:
  - `hover-magnetic`: subtle 3D tilt with cyan glow
  - `hover-liquid`: animated diagonal sheen sweep
  - `hover-depth`: text pop with depth/shadow
- Removed:
  - Scanline Sweep demo (and related CSS), leaving a no-op selector to avoid breakage

Files changed:
- `styles.css`: new classes; removed scanline implementation
- `playground.html`: added three demo boxes; removed scanline demo tile

Fixes #<issue_number_if_any>

## 🛠️ Type of Change
- [x] New feature ✨
- [x] Bug fix 🐛
- [x] Code refactor 🔨
- [ ] Documentation update 📚
- [ ] Other (please describe):

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests (N/A for styling-only changes)
- [ ] I have linked the issue using `Fixes #issue_number` (if applicable)

## 🧪 How to Test
1. Open `playground.html`.
2. Hover the boxes labeled:
   - Magnetic 3D
   - Liquid Sheen
   - Depth Text
3. Confirm the Scanline Sweep tile is no longer present.

## 📸 Screenshots
<!-- Replace with actual screenshots/gifs -->
- Before: (optional)
- After: (add your screenshots/gifs here)

## 📚 Related
- Fork: `notAryan10/AnimateItNow`
- Upstream: `itsAnimation/AnimateItNow`

## 🧠 Additional Context
- Effects are light/dark friendly and require no additional dependencies.