### PR TITLE
Move Inline Styles from templates.html to External CSS

### DIFF
--- a/templates.css
+++ b/templates.css
@@ -1,0 +1,474 @@
+/* Removed conflicting navbar CSS, relying on styles.css */
+.navbar {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  position: fixed;
+  width: 100%;
+}
+.nav-right {
+  display: flex;
+  gap: 1.5rem;
+}
+a {
+  text-decoration: none;
+}
+/* 🌒 DARK MODE GLOBAL TEXT FIXES */
+/* Changed 'dark-theme' to 'dark' to match script.js and other pages */
+body.dark {
+  background-color: #121212;
+  color: #f5f5f5;
+  background: url(images/bgdark.png) no-repeat center center fixed;
+  background-size: cover;
+  background-position: center;
+}
+/* ✅ Heading fix */
+body.dark .templates-main h1 {
+  background: linear-gradient(
+    to right,
+    #67e8f9,
+    #3b82f6
+  ); /*bright neon cyan-blue */
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  text-shadow: 0 2px 10px rgba(56, 189, 248, 0.4);
+}
+/* ✅ Template card titles */
+body.dark .template-card h2 {
+  color: #e0f2fe;
+  text-shadow: 0 0 4px rgba(147, 197, 253, 0.5);
+}
+/* ✅ Button text */
+body.dark .template-btn {
+  color: #ffffff;
+  background-color: #333;
+  border: 1px solid #555;
+}
+body.dark .template-btn:hover {
+  background-color: #444;
+  color: #fff;
+}
+/* ✅ Navbar items */
+body.dark .navbar,
+body.dark .nav-links a,
+body.dark .site-name {
+  background-color: #1a1a1a;
+  color: #ffffff;
+}
+body.dark .nav-links a:hover {
+  color: #90caf9;
+}
+/* 🧼 Remove margins to prevent light-space bleed */
+body,
+html {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  overflow-x: hidden;
+}
+/* 💡 Smooth transitions */
+.templates-main h1,
+.template-card h2,
+.template-btn,
+.navbar,
+.nav-links a {
+  transition: color 0.3s ease, background-color 0.3s ease;
+}
+/* ✨ Make text inside template cards fully visible */
+body.dark .template-card h2,
+body.dark .template-btn,
+body.dark .template-card {
+  color: #ffffff;
+}
+/* 🎯 Bonus: ensure buttons look clickable and clean */
+body.dark .template-btn {
+  background-color: #333;
+  border: 1px solid #555;
+}
+body.dark .template-btn:hover {
+  background-color: #444;
+  color: #ffffff;
+}
+/* 🔧 Template card container */
+body.dark .template-card {
+  background-color: rgba(30, 41, 59, 0.6);
+  border: 1px solid rgba(59, 130, 246, 0.15);
+  box-shadow: 0 0 6px rgba(59, 130, 246, 0.25),
+    0 0 12px rgba(56, 189, 248, 0.3);
+  color: #ffffff;
+  animation: darkNeonPulse 4s ease-in-out infinite;
+}
+/* 🖋 Titles inside cards */
+body.dark .template-card h2 {
+  color: #ffffff;
+}
+/* 🔘 Buttons */
+body.dark .template-btn {
+  color: #ffffff;
+  background-color: #333;
+  border: 1px solid #555;
+}
+/* 🖱 Hover effect for buttons */
+body.dark .template-btn:hover {
+  background-color: #444;
+  color: #ffffff;
+}
+/* 🪄 Smooth transitions */
+.template-card h2,
+.template-btn {
+  transition: color 0.3s ease, background-color 0.3s ease;
+}
+/* Base preview style */
+.template-preview {
+  height: 90px;
+  border-radius: 10px;
+  margin-bottom: 12px;
+  background-color: #f0f0f0;
+  box-shadow: 0 2px 6px rgb(0 0 0 / 0.1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px;
+  box-sizing: border-box;
+}
+/* Dark mode support */
+/* Changed 'dark-theme' to 'dark' */
+body.dark .template-preview {
+  background-color: #2a2a2a;
+  box-shadow: 0 2px 6px rgb(255 255 255 / 0.1);
+}
+/* Feature Cards Preview */
+.feature-preview {
+  background-color: #4f8cff;
+  padding: 12px;
+  gap: 10px;
+}
+.feature-preview .mini-card {
+  background-color: white;
+  flex: 1;
+  border-radius: 6px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  color: #555;
+  font-weight: 600;
+}
+/* Hero Section Preview */
+.hero-preview {
+  background-color: #4f8cff;
+  flex-direction: column;
+  padding: 14px;
+  gap: 8px;
+}
+.hero-preview .hero-image {
+  background-color: white;
+  border-radius: 8px;
+  width: 100%;
+  height: 50px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+}
+.hero-preview .hero-text-line {
+  background-color: white;
+  border-radius: 5px;
+  height: 8px;
+  width: 80%;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+}
+.hero-preview .hero-text-line.short {
+  width: 50%;
+}
+/* Social Share Preview */
+.social-share-preview {
+  background-color: #4f8cff;
+  gap: 15px;
+  font-size: 28px;
+  color: white;
+}
+.social-share-preview .social-icon-preview {
+  transition: transform 0.2s ease-in-out;
+}
+.social-share-preview:hover .social-icon-preview {
+  transform: scale(1.1);
+}
+/* Navbar Preview */
+.navbar-preview {
+  background-color: #4f8cff;
+  flex-direction: column;
+  justify-content: center;
+  padding: 12px;
+  gap: 8px;
+}
+.navbar-line {
+  height: 10px;
+  border-radius: 5px;
+  background-color: white;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+.navbar-line.logo {
+  width: 40%;
+}
+.navbar-line.link {
+  width: 70%;
+}
+.navbar-line.link.short {
+  width: 50%;
+}
+/* Make the link a flex container to align items */
+.logo-link {
+  display: flex; /* Aligns logo and text horizontally */
+  align-items: center; /* Centers them vertically */
+  gap: 10px; /* Adds space between logo and text */
+  text-decoration: none; /* Removes underline */
+  color: inherit; /* Inherits text color (if needed) */
+}
+
+/* Ensure the logo image stays aligned */
+.logo-link img.logo {
+  height: 40px; /* Adjust as needed */
+  width: auto; /* Maintains aspect ratio */
+}
+
+/* Style the text (optional) */
+.site-name {
+  font-size: 1.2rem; /* Adjust size */
+  font-weight: bold; /* Optional: Bold text */
+  pointer-events: none; /* Ensures clicks pass to parent <a> */
+}
+
+/* Hover effect (optional) */
+.logo-link:hover {
+  opacity: 0.8;
+  cursor: pointer;
+}
+/* ADDED: Animated Toggles Preview CSS */
+.toggles-preview {
+  background-color: #4f8cff;
+  gap: 20px;
+}
+.mini-toggle {
+  width: 50px;
+  height: 25px;
+  background-color: #ccc;
+  border-radius: 25px;
+  position: relative;
+  padding: 3px;
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+.mini-handle {
+  width: 19px;
+  height: 19px;
+  background-color: white;
+  border-radius: 50%;
+  position: absolute;
+  transition: transform 0.3s ease;
+}
+.mini-toggle.off .mini-handle {
+  transform: translateX(0);
+}
+.mini-toggle.on {
+  background-color: #25d366; /* A nice 'on' color */
+}
+.mini-toggle.on .mini-handle {
+  transform: translateX(25px);
+}
+/*Display Properties Preview */
+.display-preview {
+  background-color: #4f8cff;
+  height: 90px;
+  border-radius: 10px;
+  margin-bottom: 12px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+}
+.display-box {
+  border-radius: 4px;
+  display: inline-block;
+}
+.display-box.box1 {
+  width: 24px;
+  height: 24px;
+  background-color: #bbdefb;
+}
+.display-box.box2 {
+  width: 24px;
+  height: 32px;
+  background-color: #90caf9;
+}
+.display-box.box3 {
+  width: 24px;
+  height: 28px;
+  background-color: #64b5f6;
+}
+.code-play-preview {
+  font-size: 1rem;
+  font-weight: bold;
+}
+/* 🌙 Dark Theme Support */
+body.dark .display-preview {
+  background-color: #2a2a2a;
+  box-shadow: 0 2px 6px rgba(255, 255, 255, 0.1);
+}
+
+/* start for game animation */
+
+h1 {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+.nav {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 2rem;
+}
+.nav button {
+  padding: 0.75rem 1.5rem;
+  margin: 0 0.5rem;
+  border: none;
+  background: #0b5ed7;
+  color: white;
+  cursor: pointer;
+  border-radius: 6px;
+}
+.nav button:hover {
+  background: #084bb3;
+}
+.section {
+  display: none;
+}
+.section.active {
+  display: block;
+}
+.container {
+  max-width: 1000px;
+  margin: auto;
+}
+.box {
+  width: 100px;
+  height: 100px;
+  background-color: coral;
+  margin: 2rem auto;
+}
+.snippets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+.snippet {
+  background: #fff;
+  border: 2px dashed #ccc;
+  padding: 1rem;
+  width: 250px;
+  cursor: grab;
+  user-select: none;
+}
+.dropzone {
+  border: 2px solid #0b5ed7;
+  min-height: 60px;
+  padding: 1rem;
+  background: #e7f1ff;
+  margin-top: 1rem;
+}
+.button {
+  display: inline-block;
+  margin: 1rem;
+  padding: 0.75rem 2rem;
+  background: #0b5ed7;
+  color: white;
+  border: none;
+  border-radius: 0.5rem;
+  cursor: pointer;
+}
+.button:hover {
+  background: #084bb3;
+}
+.code-block {
+  background: #f8f8f8;
+  padding: 0.5rem;
+  margin-top: 0.5rem;
+  border-radius: 0.25rem;
+  font-size: 0.9rem;
+}
+
+/* Speed Fix styles */
+.fix-container {
+  background: #fff;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+}
+.code-area,
+.fix-input {
+  background: #eef;
+  padding: 1rem;
+  border-radius: 4px;
+  font-family: monospace;
+  white-space: pre-wrap;
+  width: 100%;
+  box-sizing: border-box;
+}
+.fix-input {
+  height: 200px;
+  border: 1px solid #ccc;
+}
+.timer {
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: red;
+  margin-bottom: 1rem;
+}
+.result {
+  margin-top: 1rem;
+  font-weight: bold;
+}
+
+/* end for game animation */
+/* NEW: CSS Snippet Generator Preview */
+.generator-preview {
+  background-color: #4f8cff;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  gap: 10px;
+  padding: 10px;
+}
+
+.generator-box {
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  transition: transform 0.3s ease;
+}
+
+.generator-box.box-shadow-preview {
+  background-color: white;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+}
+
+.generator-box.gradient-preview {
+  background: linear-gradient(45deg, #ff6b6b, #4f8cff);
+}
+
+.generator-box.border-radius-preview {
+  background-color: white;
+  border-radius: 50%;
+}
+
+body.dark .generator-box.box-shadow-preview {
+  background-color: #333;
+  box-shadow: 0 4px 10px rgba(255, 255, 255, 0.1);
+}
+
+body.dark .generator-box.border-radius-preview {
+  background-color: #333;
+}

--- a/templates.html
+++ b/templates.html
@@ -9,7 +9,6 @@
       content="A comprehensive collection of CSS animation templates and effects for web developers"
     />
 
-    <!-- PWA Meta Tags -->
     <meta name="theme-color" content="#ff6b6b" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
@@ -20,10 +19,8 @@
     />
     <meta name="msapplication-TileColor" content="#ff6b6b" />
 
-    <!-- PWA Manifest -->
     <link rel="manifest" href="manifest.json" />
 
-    <!-- PWA Icons -->
     <link
       rel="icon"
       type="image/png"
@@ -73,7 +70,6 @@
       href="images/icons/icon-512x512.png"
     />
 
-    <!-- Apple Touch Icons -->
     <link
       rel="apple-touch-icon"
       sizes="152x152"
@@ -85,767 +81,276 @@
       href="images/icons/icon-192x192.png"
     />
 
-    <!-- Fallback icon -->
     <link rel="icon" type="image/png" href="images/logo.png" />
     <link rel="stylesheet" href="styles.css" />
     <link
       rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+      integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/20L+oBqW+p10Xf15C13D1I+xH+E+hK+4b+f+V+F+I+C+d/I+B/I+T/I+A=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
     />
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css"
-    />
-
-    <style>
-      /* Removed conflicting navbar CSS, relying on styles.css */
-      .navbar {
-        display: flex;
-        flex-direction: row;
-        justify-content: space-between;
-        align-items: center;
-        position: fixed;
-        width: 100%;
-      }
-      .nav-right {
-        display: flex;
-        gap: 1.5rem;
-      }
-      a {
-        text-decoration: none;
-      }
-      /* 🌒 DARK MODE GLOBAL TEXT FIXES */
-      /* Changed 'dark-theme' to 'dark' to match script.js and other pages */
-      body.dark {
-        background-color: #121212;
-        color: #f5f5f5;
-        background: url(images/bgdark.png) no-repeat center center fixed;
-        background-size: cover;
-        background-position: center;
-      }
-      /* ✅ Heading fix */
-      body.dark .templates-main h1 {
-        background: linear-gradient(
-          to right,
-          #67e8f9,
-          #3b82f6
-        ); /*bright neon cyan-blue */
-        -webkit-background-clip: text;
-        background-clip: text;
-        -webkit-text-fill-color: transparent;
-        text-shadow: 0 2px 10px rgba(56, 189, 248, 0.4);
-      }
-      /* ✅ Template card titles */
-      body.dark .template-card h2 {
-        color: #e0f2fe;
-        text-shadow: 0 0 4px rgba(147, 197, 253, 0.5);
-      }
-      /* ✅ Button text */
-      body.dark .template-btn {
-        color: #ffffff;
-        background-color: #333;
-        border: 1px solid #555;
-      }
-      body.dark .template-btn:hover {
-        background-color: #444;
-        color: #fff;
-      }
-      /* ✅ Navbar items */
-      body.dark .navbar,
-      body.dark .nav-links a,
-      body.dark .site-name {
-        background-color: #1a1a1a;
-        color: #ffffff;
-      }
-      body.dark .nav-links a:hover {
-        color: #90caf9;
-      }
-      /* 🧼 Remove margins to prevent light-space bleed */
-      body,
-      html {
-        margin: 0;
-        padding: 0;
-        width: 100%;
-        overflow-x: hidden;
-      }
-      /* 💡 Smooth transitions */
-      .templates-main h1,
-      .template-card h2,
-      .template-btn,
-      .navbar,
-      .nav-links a {
-        transition: color 0.3s ease, background-color 0.3s ease;
-      }
-      /* ✨ Make text inside template cards fully visible */
-      body.dark .template-card h2,
-      body.dark .template-btn,
-      body.dark .template-card {
-        color: #ffffff;
-      }
-      /* 🎯 Bonus: ensure buttons look clickable and clean */
-      body.dark .template-btn {
-        background-color: #333;
-        border: 1px solid #555;
-      }
-      body.dark .template-btn:hover {
-        background-color: #444;
-        color: #ffffff;
-      }
-      /* 🔧 Template card container */
-      body.dark .template-card {
-        background-color: rgba(30, 41, 59, 0.6);
-        border: 1px solid rgba(59, 130, 246, 0.15);
-        box-shadow: 0 0 6px rgba(59, 130, 246, 0.25),
-          0 0 12px rgba(56, 189, 248, 0.3);
-        color: #ffffff;
-        animation: darkNeonPulse 4s ease-in-out infinite;
-      }
-      /* 🖋 Titles inside cards */
-      body.dark .template-card h2 {
-        color: #ffffff;
-      }
-      /* 🔘 Buttons */
-      body.dark .template-btn {
-        color: #ffffff;
-        background-color: #333;
-        border: 1px solid #555;
-      }
-      /* 🖱 Hover effect for buttons */
-      body.dark .template-btn:hover {
-        background-color: #444;
-        color: #ffffff;
-      }
-      /* 🪄 Smooth transitions */
-      .template-card h2,
-      .template-btn {
-        transition: color 0.3s ease, background-color 0.3s ease;
-      }
-      /* Base preview style */
-      .template-preview {
-        height: 90px;
-        border-radius: 10px;
-        margin-bottom: 12px;
-        background-color: #f0f0f0;
-        box-shadow: 0 2px 6px rgb(0 0 0 / 0.1);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        gap: 8px;
-        padding: 10px;
-        box-sizing: border-box;
-      }
-      /* Dark mode support */
-      /* Changed 'dark-theme' to 'dark' */
-      body.dark .template-preview {
-        background-color: #2a2a2a;
-        box-shadow: 0 2px 6px rgb(255 255 255 / 0.1);
-      }
-      /* Feature Cards Preview */
-      .feature-preview {
-        background-color: #4f8cff;
-        padding: 12px;
-        gap: 10px;
-      }
-      .feature-preview .mini-card {
-        background-color: white;
-        flex: 1;
-        border-radius: 6px;
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
-        height: 60px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        font-size: 12px;
-        color: #555;
-        font-weight: 600;
-      }
-      /* Hero Section Preview */
-      .hero-preview {
-        background-color: #4f8cff;
-        flex-direction: column;
-        padding: 14px;
-        gap: 8px;
-      }
-      .hero-preview .hero-image {
-        background-color: white;
-        border-radius: 8px;
-        width: 100%;
-        height: 50px;
-        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
-      }
-      .hero-preview .hero-text-line {
-        background-color: white;
-        border-radius: 5px;
-        height: 8px;
-        width: 80%;
-        box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
-      }
-      .hero-preview .hero-text-line.short {
-        width: 50%;
-      }
-      /* Social Share Preview */
-      .social-share-preview {
-        background-color: #4f8cff;
-        gap: 15px;
-        font-size: 28px;
-        color: white;
-      }
-      .social-share-preview .social-icon-preview {
-        transition: transform 0.2s ease-in-out;
-      }
-      .social-share-preview:hover .social-icon-preview {
-        transform: scale(1.1);
-      }
-      /* Navbar Preview */
-      .navbar-preview {
-        background-color: #4f8cff;
-        flex-direction: column;
-        justify-content: center;
-        padding: 12px;
-        gap: 8px;
-      }
-      .navbar-line {
-        height: 10px;
-        border-radius: 5px;
-        background-color: white;
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
-      }
-      .navbar-line.logo {
-        width: 40%;
-      }
-      .navbar-line.link {
-        width: 70%;
-      }
-      .navbar-line.link.short {
-        width: 50%;
-      }
-      /* Make the link a flex container to align items */
-      .logo-link {
-        display: flex;         /* Aligns logo and text horizontally */
-        align-items: center;  /* Centers them vertically */
-        gap: 10px;            /* Adds space between logo and text */
-        text-decoration: none; /* Removes underline */
-        color: inherit;       /* Inherits text color (if needed) */
-      }
-
-      /* Ensure the logo image stays aligned */
-      .logo-link img.logo {
-        height: 40px;          /* Adjust as needed */
-        width: auto;          /* Maintains aspect ratio */
-      }
-
-      /* Style the text (optional) */
-      .site-name {
-        font-size: 1.2rem;    /* Adjust size */
-        font-weight: bold;    /* Optional: Bold text */
-        pointer-events: none; /* Ensures clicks pass to parent <a> */
-      }
-
-      /* Hover effect (optional) */
-      .logo-link:hover {
-        opacity: 0.8;
-        cursor: pointer;
-      }
-      /* ADDED: Animated Toggles Preview CSS */
-      .toggles-preview {
-        background-color: #4f8cff;
-        gap: 20px;
-      }
-      .mini-toggle {
-        width: 50px;
-        height: 25px;
-        background-color: #ccc;
-        border-radius: 25px;
-        position: relative;
-        padding: 3px;
-        box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.2);
-      }
-      .mini-handle {
-        width: 19px;
-        height: 19px;
-        background-color: white;
-        border-radius: 50%;
-        position: absolute;
-        transition: transform 0.3s ease;
-      }
-      .mini-toggle.off .mini-handle {
-        transform: translateX(0);
-      }
-      .mini-toggle.on {
-        background-color: #25d366; /* A nice 'on' color */
-      }
-      .mini-toggle.on .mini-handle {
-        transform: translateX(25px);
-      }
-      /*Display Properties Preview */
-      .display-preview {
-        background-color: #4f8cff;
-        height: 90px;
-        border-radius: 10px;
-        margin-bottom: 12px;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        gap: 8px;
-        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
-      }
-      .display-box {
-        border-radius: 4px;
-        display: inline-block;
-      }
-      .display-box.box1 {
-        width: 24px;
-        height: 24px;
-        background-color: #bbdefb;
-      }
-      .display-box.box2 {
-        width: 24px;
-        height: 32px;
-        background-color: #90caf9;
-      }
-      .display-box.box3 {
-        width: 24px;
-        height: 28px;
-        background-color: #64b5f6;
-      }
-      .code-play-preview {
-        font-size: 1rem;
-        font-weight: bold;
-      }
-      /* 🌙 Dark Theme Support */
-      body.dark .display-preview {
-        background-color: #2a2a2a;
-        box-shadow: 0 2px 6px rgba(255, 255, 255, 0.1);
-      }
-
-      /* start for game animation */
-
-      h1 {
-        text-align: center;
-        margin-bottom: 2rem;
-      }
-      .nav {
-        display: flex;
-        justify-content: center;
-        margin-bottom: 2rem;
-      }
-      .nav button {
-        padding: 0.75rem 1.5rem;
-        margin: 0 0.5rem;
-        border: none;
-        background: #0b5ed7;
-        color: white;
-        cursor: pointer;
-        border-radius: 6px;
-      }
-      .nav button:hover {
-        background: #084bb3;
-      }
-      .section {
-        display: none;
-      }
-      .section.active {
-        display: block;
-      }
-      .container {
-        max-width: 1000px;
-        margin: auto;
-      }
-      .box {
-        width: 100px;
-        height: 100px;
-        background-color: coral;
-        margin: 2rem auto;
-      }
-      .snippets {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 1rem;
-        justify-content: center;
-      }
-      .snippet {
-        background: #fff;
-        border: 2px dashed #ccc;
-        padding: 1rem;
-        width: 250px;
-        cursor: grab;
-        user-select: none;
-      }
-      .dropzone {
-        border: 2px solid #0b5ed7;
-        min-height: 60px;
-        padding: 1rem;
-        background: #e7f1ff;
-        margin-top: 1rem;
-      }
-      .button {
-        display: inline-block;
-        margin: 1rem;
-        padding: 0.75rem 2rem;
-        background: #0b5ed7;
-        color: white;
-        border: none;
-        border-radius: 0.5rem;
-        cursor: pointer;
-      }
-      .button:hover {
-        background: #084bb3;
-      }
-      .code-block {
-        background: #f8f8f8;
-        padding: 0.5rem;
-        margin-top: 0.5rem;
-        border-radius: 0.25rem;
-        font-size: 0.9rem;
-      }
-
-      /* Speed Fix styles */
-      .fix-container {
-        background: #fff;
-        padding: 2rem;
-        border-radius: 8px;
-        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-      }
-      .code-area,
-      .fix-input {
-        background: #eef;
-        padding: 1rem;
-        border-radius: 4px;
-        font-family: monospace;
-        white-space: pre-wrap;
-        width: 100%;
-        box-sizing: border-box;
-      }
-      .fix-input {
-        height: 200px;
-        border: 1px solid #ccc;
-      }
-      .timer {
-        font-size: 1.5rem;
-        font-weight: bold;
-        color: red;
-        margin-bottom: 1rem;
-      }
-      .result {
-        margin-top: 1rem;
-        font-weight: bold;
-      }
-
-      /* end for game animation */
-      /* NEW: CSS Snippet Generator Preview */
-      .generator-preview {
-        background-color: #4f8cff;
-        display: flex;
-        justify-content: space-around;
-        align-items: center;
-        gap: 10px;
-        padding: 10px;
-      }
-
-      .generator-box {
-        width: 40px;
-        height: 40px;
-        border-radius: 8px;
-        box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-        transition: transform 0.3s ease;
-      }
-
-      .generator-box.box-shadow-preview {
-        background-color: white;
-        box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
-      }
-
-      .generator-box.gradient-preview {
-        background: linear-gradient(45deg, #ff6b6b, #4f8cff);
-      }
-
-      .generator-box.border-radius-preview {
-        background-color: white;
-        border-radius: 50%;
-      }
-
-      body.dark .generator-box.box-shadow-preview {
-        background-color: #333;
-        box-shadow: 0 4px 10px rgba(255, 255, 255, 0.1);
-      }
-
-      body.dark .generator-box.border-radius-preview {
-        background-color: #333;
-      }
-    </style>
   </head>
   <body class="dark">
-    <nav class="navbar scroll-fade">
-      <div class="nav-left">
-        <a href="/" class="logo-link">
-          <img src="images/logo.png" alt="AnimateItNow Logo" class="logo" />
-          <span class="site-name">Animate It Now</span>
-        </a>
-      </div>
-
-      <div class="nav-right">
-        <ul class="nav-links">
-          <li><a href="index.html">Home</a></li>
-          <li><a href="about.html">About</a></li>
-          <li><a href="editor.html" target="_blank">Editor</a></li>
-          <li><a href="templates.html" class="active">Templates</a></li>
-          <li><a href="playground.html" style="white-space: nowrap">Hover-Effects</a></li>
-          <li><a href="contributors.html">Contributors</a></li>
-          <li><a href="contact.html">Contact</a></li>
-          <li><a href="leaderboard.html">Leaderboard</a></li>
-          <li><a href="generator.html">Generator</a></li>
-          <!-- cursor toggle switch -->
-          <li>
-            <label class="switch" title="Toggle Snake Cursor">
-              <input type="checkbox" id="cursorToggle" />
-              <span class="slider round"></span>
-            </label>
-          </li>
-          <!-- github icon -->
-          <li>
-            <a
-              href="https://github.com/itsAnimation/AnimateItNow"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="GitHub Repo"
-              class="github-icon"
-            >
-              <svg
-                viewBox="0 0 16 16"
-                width="24"
-                height="24"
-                fill="currentColor"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 
-                7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49
-                -2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13
-                -.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82
-                .72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07
-                -1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15
-                -.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82
-                .64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27
-                1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12
-                .51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95
-                .29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2
-                0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"
-                />
-              </svg>
-            </a>
-          </li>
-          <li>
-            <button id="theme-toggle" aria-label="Toggle Theme">
-              <i data-lucide="moon"></i>
-            </button>
-          </li>
-        </ul>
-      </div>
-    </nav>
-    <main class="templates-main">
-      <h1>Templates Gallery</h1>
-      <div
-        style="display: flex; justify-content: center; margin-bottom: 1.5rem"
-      >
-        <input
-          type="text"
-          id="search-bar"
-          placeholder="Search templates..."
-          style="
-            color: #1f2937;
-            padding: 0.6rem 1.2rem;
-            background: linear-gradient(to right, #67e8f9, #60a5fa);
-            box-shadow: 0 6px 18px rgba(96, 165, 250, 0.25);
-            border-radius: 18px;
-            border: 1px solid #ccc;
-            min-width: 420px;
-            font-size: 1rem;
-            outline: none;
-          "
-          aria-label="Search templates"
-        />
-      </div>
-        <div class="no-results">
-  No Templates Found.
-</div>
-      <section class="templates-grid">
-        <a class="template-card" href="templates/LoginFormGlassMorphism.html">
-          <h2>Login Form with Glassmorphism.</h2>
-          <div class="template-preview login-preview">
-            <div class="page link"></div>
-          </div>
-          <button class="template-btn">View Template</button>
-        </a>
-        <a class="template-card" href="templates/login.html">
-          <h2>Login Page UI</h2>
-          <div class="template-preview login-preview"></div>
-          <button class="template-btn">View Template</button>
-        </a>
-        <a class="template-card" href="templates/button.html">
-          <h2>Hover Button Effects</h2>
-          <div class="template-preview button-preview"></div>
-          <button class="template-btn">View Template</button>
-        </a>
-        <a class="template-card" href="templates/loader.html">
-          <h2>Loaders</h2>
-          <div class="template-preview loader-preview"></div>
-          <button class="template-btn">View Template</button>
-        </a>
-        <!-- aading texts effects -->
-        <a class="template-card" href="templates/text_effects_anim.html">
-          <h2>Text Animation Effects</h2>
-          <div class="template-preview text-preview">
-            <h2 id="textTarget"></h2>
-          </div>
-          <button class="template-btn">View Template</button>
-        </a>
-        <a class="template-card" href="templates/modal.html">
-          <h2>Popup Templates</h2>
-          <div class="template-preview modal-preview"></div>
-          <button class="template-btn">View Template</button>
-        </a>
-        <a class="template-card" href="templates/glassmorphism.html">
-          <h2>Glassmorphism profile card</h2>
-          <div class="template-preview modal-preview"></div>
-          <button class="template-btn">View Template</button>
-        </a>
-        <!-- adding code Playground -->
-        <a class="template-card" href="templates/code_playground.html">
-          <h2>Code PlayGround</h2>
-          <div class="template-preview code-play-preview">Write Code</div>
-          <button class="template-btn">View Template</button>
-        </a>
-
-        <a class="template-card" href="templates/feature.html">
-          <h2>Feature Cards UI</h2>
-          <div class="template-preview feature-preview">
-            <div class="mini-card">Card1</div>
-            <div class="mini-card">Card2</div>
-            <div class="mini-card">Card3</div>
-          </div>
-          <button class="template-btn">View Template</button>
-        </a>
-        <a class="template-card" href="templates/hero.html">
-          <h2>Hero Section Template</h2>
-          <div class="template-preview hero-preview">
-            <div class="hero-image"></div>
-            <div class="hero-text-line"></div>
-            <div class="hero-text-line short"></div>
-          </div>
-          <button class="template-btn">View Template</button>
-        </a>
-        <article class="template-card">
-          <h2>Animated Button</h2>
-          <div class="template-preview button-preview"></div>
-          <a class="template-btn" href="templates/animated-btn.html"
-            >View Template</a
-          >
-        </article>
-        <a class="template-card" href="templates/social-share-buttons.html">
-          <h2>Animated Social Share Buttons</h2>
-          <div class="template-preview social-share-preview">
-            <i class="fab fa-facebook-f social-icon-preview"></i>
-            <i class="fab fa-twitter social-icon-preview"></i>
-            <i class="fab fa-instagram social-icon-preview"></i>
-          </div>
-          <button class="template-btn">View Template</button>
-        </a>
-        <!-- CORRECTED TOOLTIP COMPONENT -->
-        <a class="template-card" href="templates/tooltip.html">
-          <h2>Tooltip UI Component</h2>
-          <div class="template-preview">
-            <button class="tooltip" data-tooltip="I’m a tooltip!">Hover</button>
-          </div>
-          <span class="template-btn">View Template</span>
-        </a>
-        <!-- Responsive Card Carousel -->
-        <a class="template-card" href="templates/carousel.html">
-          <h2>Responsive Card Carousel</h2>
-          <div class="template-preview carousel-preview">
-            <div class="mini-card"></div>
-            <div class="mini-card"></div>
-            <div class="mini-card"></div>
-          </div>
-          <span class="template-btn">View Template</span>
-        </a>
-        <!-- NEWLY ADDED ANIMATED TOGGLES CARD -->
-        <a class="template-card" href="templates/toggles-and-checkboxes.html">
-          <h2>Animated Toggles</h2>
-          <div class="template-preview toggles-preview">
-            <div class="mini-toggle off">
-              <div class="mini-handle"></div>
-            </div>
-            <div class="mini-toggle on">
-              <div class="mini-handle"></div>
-            </div>
-          </div>
-          <button class="template-btn">View Template</button>
-        </a>
-        <a class="template-card" href="templates/neumorphic.html">
-          <h2>Neumorphic Button Effects</h2>
-          <div class="template-preview neumorphic-preview"></div>
-          <button class="template-btn">View Template</button>
-        </a>
-        <a class="template-card" href="templates/navbar.html">
-          <h2>Navbar Variants</h2>
-          <div class="template-preview navbar-preview">
-            <div class="navbar-line logo"></div>
-            <div class="navbar-line link"></div>
-            <div class="navbar-line link short"></div>
-          </div>
-          <button class="template-btn">View Template</button>
-        </a>
-        <a class="template-card" href="templates/display.html">
-          <h2>Display Properties</h2>
-          <div class="template-preview display-preview">
-            <div class="display-box box1"></div>
-            <div class="display-box box2"></div>
-            <div class="display-box box3"></div>
-          </div>
-          <button class="template-btn">View Template</button>
-        </a>
-        <a class="template-card" href="templates/CardHoverEffects.html">
-          <h2>3D Card Hover Effects</h2>
-          <div class="template-preview navbar-preview">
-            <div class="navbar-line link"></div>
-          </div>
-          <button class="template-btn">View Template</button>
-        </a>
-        <a class="template-card" href="templates/page_not_found_template.html">
-          <h2>404 Page not found</h2>
-          <div class="template-preview 404-preview">
-            <div class="page link"></div>
-          </div>
-          <button class="template-btn">View Template</button>
-        </a>
-        <a class="template-card" href="templates/contact.html">
-        <h2>Contact Us Template</h2>
-        <div class="template-preview navbar-preview">
-          <div class="fas fa-envelope" style="font-size: 40px; color: white;"></div>
+    <div id="container">
+      <nav class="navbar scroll-fade">
+        <div class="nav-left">
+          <a href="/" class="logo-link">
+            <img src="images/logo.png" alt="AnimateItNow Logo" class="logo" />
+            <span class="site-name">Animate It Now</span>
+          </a>
         </div>
-        <button class="template-btn">View Template</button>
-      </a>
-        <a class="template-card" href="templates/accordian.html">
-          <h2>Accordian Template</h2>
-          <div class="template-preview 404-preview">
-            <div class="page link"></div>
-          </div>
-          <button class="template-btn">View Template</button>
-        </a>
-        <!-- NEW CARD: CSS Snippet Generator -->
-        <a class="template-card" href="generator.html">
-            <h2>CSS Snippet Generator</h2>
-            <div class="template-preview generator-preview">
-                <div class="generator-box box-shadow-preview"></div>
-                <div class="generator-box gradient-preview"></div>
-                <div class="generator-box border-radius-preview"></div>
+
+        <div class="nav-right">
+          <ul class="nav-links">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="about.html">About</a></li>
+            <li><a href="editor.html" target="_blank">Editor</a></li>
+            <li><a href="templates.html" class="active">Templates</a></li>
+            <li>
+              <a href="playground.html" style="white-space: nowrap"
+                >Hover-Effects</a
+              >
+            </li>
+            <li><a href="contributors.html">Contributors</a></li>
+            <li><a href="contact.html">Contact</a></li>
+            <li><a href="leaderboard.html">Leaderboard</a></li>
+            <li><a href="generator.html">Generator</a></li>
+            <li>
+              <label class="switch" title="Toggle Snake Cursor">
+                <input type="checkbox" id="cursorToggle" />
+                <span class="slider round"></span>
+              </label>
+            </li>
+            <li>
+              <a
+                href="https://github.com/itsAnimation/AnimateItNow"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="GitHub Repo"
+                class="github-icon"
+              >
+                <svg
+                  viewBox="0 0 16 16"
+                  width="24"
+                  height="24"
+                  fill="currentColor"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"
+                  />
+                </svg>
+              </a>
+            </li>
+            <li>
+              <button id="theme-toggle" aria-label="Toggle Theme">
+                <i data-lucide="moon"></i>
+              </button>
+            </li>
+          </ul>
+        </div>
+      </nav>
+      <main class="templates-main">
+        <h1>Templates Gallery</h1>
+        <div
+          style="display: flex; justify-content: center; margin-bottom: 1.5rem"
+        >
+          <input
+            type="text"
+            id="search-bar"
+            placeholder="Search templates..."
+            style="
+              color: #1f2937;
+              padding: 0.6rem 1.2rem;
+              background: linear-gradient(to right, #67e8f9, #60a5fa);
+              box-shadow: 0 6px 18px rgba(96, 165, 250, 0.25);
+              border-radius: 18px;
+              border: 1px solid #ccc;
+              min-width: 420px;
+              font-size: 1rem;
+              outline: none;
+            "
+            aria-label="Search templates"
+          />
+        </div>
+        <div class="no-results" style="display: none">No Templates Found.</div>
+        <section class="templates-grid">
+          <a class="template-card" href="templates/LoginFormGlassMorphism.html">
+            <h2>Login Form with Glassmorphism.</h2>
+            <div class="template-preview login-preview">
+              <div class="page link"></div>
             </div>
             <button class="template-btn">View Template</button>
-        </a>
-      </section>
-    </main>
+          </a>
+          <a class="template-card" href="templates/login.html">
+            <h2>Login Page UI</h2>
+            <div class="template-preview login-preview"></div>
+            <button class="template-btn">View Template</button>
+          </a>
+          <a class="template-card" href="templates/button.html">
+            <h2>Hover Button Effects</h2>
+            <div class="template-preview button-preview"></div>
+            <button class="template-btn">View Template</button>
+          </a>
+          <a class="template-card" href="templates/loader.html">
+            <h2>Loaders</h2>
+            <div class="template-preview loader-preview"></div>
+            <button class="template-btn">View Template</button>
+          </a>
+          <a class="template-card" href="templates/text_effects_anim.html">
+            <h2>Text Animation Effects</h2>
+            <div class="template-preview text-preview">
+              <h2 id="textTarget"></h2>
+            </div>
+            <button class="template-btn">View Template</button>
+          </a>
+          <a class="template-card" href="templates/modal.html">
+            <h2>Popup Templates</h2>
+            <div class="template-preview modal-preview"></div>
+            <button class="template-btn">View Template</button>
+          </a>
+          <a class="template-card" href="templates/glassmorphism.html">
+            <h2>Glassmorphism profile card</h2>
+            <div class="template-preview modal-preview"></div>
+            <button class="template-btn">View Template</button>
+          </a>
+          <a class="template-card" href="templates/code_playground.html">
+            <h2>Code PlayGround</h2>
+            <div class="template-preview code-play-preview">Write Code</div>
+            <button class="template-btn">View Template</button>
+          </a>
 
-    <div id="container">
+          <a class="template-card" href="templates/feature.html">
+            <h2>Feature Cards UI</h2>
+            <div class="template-preview feature-preview">
+              <div class="mini-card">Card1</div>
+              <div class="mini-card">Card2</div>
+              <div class="mini-card">Card3</div>
+            </div>
+            <button class="template-btn">View Template</button>
+          </a>
+          <a class="template-card" href="templates/hero.html">
+            <h2>Hero Section Template</h2>
+            <div class="template-preview hero-preview">
+              <div class="hero-image"></div>
+              <div class="hero-text-line"></div>
+              <div class="hero-text-line short"></div>
+            </div>
+            <button class="template-btn">View Template</button>
+          </a>
+          <a class="template-card" href="templates/animated-btn.html">
+            <h2>Animated Button</h2>
+            <div class="template-preview button-preview"></div>
+            <button class="template-btn">View Template</button>
+          </a>
+          <a class="template-card" href="templates/social-share-buttons.html">
+            <h2>Animated Social Share Buttons</h2>
+            <div class="template-preview social-share-preview">
+              <i class="fab fa-facebook-f social-icon-preview"></i>
+              <i class="fab fa-twitter social-icon-preview"></i>
+              <i class="fab fa-instagram social-icon-preview"></i>
+            </div>
+            <button class="template-btn">View Template</button>
+          </a>
+          <a class="template-card" href="templates/tooltip.html">
+            <h2>Tooltip UI Component</h2>
+            <div class="template-preview">
+              <button class="tooltip" data-tooltip="I’m a tooltip!">
+                Hover
+              </button>
+            </div>
+            <button class="template-btn">View Template</button>
+          </a>
+          <a class="template-card" href="templates/carousel.html">
+            <h2>Responsive Card Carousel</h2>
+            <div class="template-preview carousel-preview">
+              <div class="mini-card"></div>
+              <div class="mini-card"></div>
+              <div class="mini-card"></div>
+            </div>
+            <button class="template-btn">View Template</button>
+          </a>
+          <a
+            class="template-card"
+            href="templates/toggles-and-checkboxes.html"
+          >
+            <h2>Animated Toggles</h2>
+            <div class="template-preview toggles-preview">
+              <div class="mini-toggle off">
+                <div class="mini-handle"></div>
+              </div>
+              <div class="mini-toggle on">
+                <div class="mini-handle"></div>
+              </div>
+            </div>
+            <button class="template-btn">View Template</button>
+          </a>
+          <a class="template-card" href="templates/neumorphic.html">
+            <h2>Neumorphic Button Effects</h2>
+            <div class="template-preview neumorphic-preview"></div>
+            <button class="template-btn">View Template</button>
+          </a>
+          <a class="template-card" href="templates/navbar.html">
+            <h2>Navbar Variants</h2>
+            <div class="template-preview navbar-preview">
+              <div class="navbar-line logo"></div>
+              <div class="navbar-line link"></div>
+              <div class="navbar-line link short"></div>
+            </div>
+            <button class="template-btn">View Template</button>
+          </a>
+          <a class="template-card" href="templates/display.html">
+            <h2>Display Properties</h2>
+            <div class="template-preview display-preview">
+              <div class="display-box box1"></div>
+              <div class="display-box box2"></div>
+              <div class="display-box box3"></div>
+            </div>
+            <button class="template-btn">View Template</button>
+          </a>
+          <a class="template-card" href="templates/CardHoverEffects.html">
+            <h2>3D Card Hover Effects</h2>
+            <div class="template-preview navbar-preview">
+              <div class="navbar-line link"></div>
+            </div>
+            <button class="template-btn">View Template</button>
+          </a>
+          <a class="template-card" href="templates/page_not_found_template.html">
+            <h2>404 Page not found</h2>
+            <div class="template-preview 404-preview">
+              <div class="page link"></div>
+            </div>
+            <button class="template-btn">View Template</button>
+          </a>
+          <a class="template-card" href="templates/contact.html">
+            <h2>Contact Us Template</h2>
+            <div class="template-preview navbar-preview">
+              <div
+                class="fas fa-envelope"
+                style="font-size: 40px; color: white"
+              ></div>
+            </div>
+            <button class="template-btn">View Template</button>
+          </a>
+          <a class="template-card" href="templates/accordian.html">
+            <h2>Accordian Template</h2>
+            <div class="template-preview 404-preview">
+              <div class="page link"></div>
+            </div>
+            <button class="template-btn">View Template</button>
+          </a>
+          <a class="template-card" href="generator.html">
+            <h2>CSS Snippet Generator</h2>
+            <div class="template-preview generator-preview">
+              <div class="generator-box box-shadow-preview"></div>
+              <div class="generator-box gradient-preview"></div>
+              <div class="generator-box border-radius-preview"></div>
+            </div>
+            <button class="template-btn">View Template</button>
+          </a>
+        </section>
+      </main>
       <footer class="footer scroll-fade">
         <div class="footer-content">
           <div class="footer-left">
@@ -891,22 +396,15 @@
         </div>
       </footer>
     </div>
-    <!--  Removed the hardcoded cursor-snake div. script.js creates it dynamically. -->
-    <!-- <div id="cursor-snake"></div> -->
     <script src="https://unpkg.com/lucide@latest"></script>
-    <!--  Added link to your shared script.js -->
     <script src="script.js"></script>
     <script>
-      //  This script now ONLY contains functionality specific to templates.html
-      // Theme toggle and cursor logic are handled by script.js
-      // Theme toggle functionality
       const themeToggle = document.getElementById("theme-toggle");
       const body = document.body;
 
       function setTheme(isDark) {
         const newIcon = isDark ? "sun" : "moon";
-        document.getElementById("container").classList.toggle("dark", isDark);
-        body.classList.toggle("dark-theme", isDark);
+        body.classList.toggle("dark", isDark);
         localStorage.setItem("theme", isDark ? "dark" : "light");
 
         if (themeToggle) {
@@ -922,12 +420,11 @@
       setTheme(savedTheme === "dark" || (savedTheme === null && prefersDark));
 
       themeToggle?.addEventListener("click", () => {
-        setTheme(!body.classList.contains("dark-theme"));
+        setTheme(!body.classList.contains("dark"));
       });
 
       lucide.createIcons();
 
-      // Scroll animation for cards
       const observer = new IntersectionObserver(
         (entries) => {
           entries.forEach((entry) => {
@@ -942,10 +439,9 @@
         observer.observe(card);
       });
 
-      // Search & Category Filter Functionality
       const searchBar = document.getElementById("search-bar");
       const templateCards = document.querySelectorAll(".template-card");
-      const noResultsMsg = document.querySelector(".no-results"); // Added a "no results" div to your HTML
+      const noResultsMsg = document.querySelector(".no-results");
 
       function filterTemplates() {
         const query = searchBar.value.trim().toLowerCase();
@@ -956,7 +452,7 @@
             .querySelector("h2")
             .textContent.trim()
             .toLowerCase();
-          const matchesTitle = title.includes(query); // 'includes' is better than 'startsWith' for search
+          const matchesTitle = title.includes(query);
           if (matchesTitle) {
             card.style.display = "";
             visibleCount++;
@@ -966,14 +462,11 @@
         });
 
         if (noResultsMsg) {
-
-          noResultsMsg.style.display = visibleCount === 0 ? 'block' : 'none';
+          noResultsMsg.style.display = visibleCount === 0 ? "block" : "none";
         }
-      
       }
       searchBar.addEventListener("input", filterTemplates);
 
-      //script for animation type one after other
       const texts = [
         "Typing Animation",
         "Gradient Text",
@@ -982,12 +475,12 @@
         "Zoom on Hover",
       ];
 
-      let currTextIdx = 0; // Index of current string in the array
-      let charIdx = 0; // index of current char currently being typed /deleted
+      let currTextIdx = 0;
+      let charIdx = 0;
       let isDelete = false;
 
-      const speed = 100; //type/delete speed
-      const pausTime = 1000; //pause time
+      const speed = 100;
+      const pausTime = 1000;
       const target = document.getElementById("textTarget");
 
       function typeLoop() {
@@ -998,8 +491,7 @@
         } else {
           target.textContent = currentText.substring(0, charIdx++);
         }
-        //typed full character
-        if (!isDelete && charIdx === currentText.length + 1) {
+        if (!isDelete && charIdx > currentText.length) {
           setTimeout(() => {
             isDelete = true;
             typeLoop();
@@ -1007,18 +499,21 @@
           return;
         }
 
-        //move to next char when deleted
-        if (isDelete && charIdx === 0) {
+        if (isDelete && charIdx < 0) {
           isDelete = false;
-          //use modulo so that it can reback at 0
           currTextIdx = (currTextIdx + 1) % texts.length;
+          setTimeout(() => typeLoop(), speed);
+          return;
         }
 
-        // Deleting is faster (half the speed)
-        // Typing is slower
-        setTimeout(typeLoop, isDelete ? speed / 2 : speed);
+        setTimeout(typeLoop, speed);
       }
-      typeLoop(); // start animation
+
+      document.addEventListener("DOMContentLoaded", () => {
+        if (target) {
+          typeLoop();
+        }
+      });
     </script>
   </body>
 </html>

--- a/templates.html
+++ b/templates.html
@@ -82,7 +82,7 @@
     />
 
     <link rel="icon" type="image/png" href="images/logo.png" />
-    <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="templates.css" />
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"


### PR DESCRIPTION
issue #695 

## 📄 Description
This pull request refactors the `templates.html` file by separating its internal CSS into a dedicated external file, `templates.css`. This change improves code organization, making the project easier to maintain and debug. It also addresses minor styling bugs related to the dark mode implementation by ensuring all styles are correctly applied from a single source.

## 🛠️ Type of Change
- [x] Bug fix 🐛
- [x] Code refactor 🔨

---

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have linked the issue using `Fixes #issue_number`
---

## 🧠 Additional Context
Splitting the CSS from the HTML adheres to a core web development principles. This makes the code cleaner, more readable, and allows for better caching by the browser. It will be easier for new contributors to locate and modify styling without having to parse through the entire HTML document.
```
