### PR TITLE
🛠️ Fix: Remove references to missing `pwa.js` file to prevent 404 errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -617,7 +617,7 @@
 
     <script src="script.js"></script>
     <!-- PWA Support -->
-    <script src="pwa.js"></script>
+    <!-- <script src="pwa.js"></script> -->
 
     <!-- testimonials-effect-animations -->
     <!-- GSSOC'25 Contributor : 6vam4arya -->

--- a/playground.html
+++ b/playground.html
@@ -173,7 +173,7 @@
   </script>
   <script src="script.js"></script>
   <!-- PWA Support -->
-  <script src="pwa.js"></script>
+  <!-- <script src="pwa.js"></script> -->
     
 </body>
 </html>

--- a/templates/code_playground.html
+++ b/templates/code_playground.html
@@ -458,7 +458,6 @@
         }
     </script>
     <!-- PWA Support -->
-    <script src="../pwa.js"></script>
 
     <div id="cursor-snake"></div>
     <script src="../script.js"></script>

--- a/templates/text_effects_anim.html
+++ b/templates/text_effects_anim.html
@@ -557,7 +557,6 @@
       // });
     </script>
     <!-- PWA Support -->
-    <script src="../pwa.js"></script>
 
     <div id="cursor-snake"></div>
     <script src="../script.js"></script>


### PR DESCRIPTION

Close: #1214 


## 🐞 Problem
The project contained references to a missing `pwa.js` file in multiple HTML pages:  

- `index.html`  
- `playground.html`  
- `templates/code_playground.html`  
- `templates/text_effects_anim.html`  

These missing file references were causing **404 errors** when loading the pages, negatively impacting site performance and user experience.

---

## 💡 Solution
All references to the missing `pwa.js` file have been **removed** by commenting out the script tags that attempted to load it.  

This prevents 404 errors while maintaining all other functionality.

---

## 🔄 Changes Made
- `index.html`: Commented out `<script src="pwa.js"></script>` on line 619  
- `playground.html`: Commented out `<script src="pwa.js"></script>` on line 175  
- `templates/code_playground.html`: Commented out `<script src="../pwa.js"></script>`  
- `templates/text_effects_anim.html`: Commented out `<script src="../pwa.js"></script>`  

---

## ✅ How it fixes the issue
By removing references to the non-existent `pwa.js` file:  
- **404 errors** are eliminated  
- **Site performance** improves  
- **Console errors** are prevented  

The PWA functionality was already disabled in `script.js`, so this change does **not affect any existing features**.

---

## 📝 Extra Notes
The service worker registration code in `script.js` was already commented out, indicating that PWA functionality was intentionally disabled.  
The leftover `pwa.js` script references were simply overlooked. This PR ensures **consistency across the codebase**.
