### PR TITLE
Login Form now linked to login/signup form

### DIFF
--- a/templates.html
+++ b/templates.html
@@ -204,7 +204,7 @@
         description: "Beautiful authentication forms with smooth transitions between states.",
         category: "form",
         icon: "fas fa-user",
-        link: "templates/auth-forms.html"
+        link: "templates/LoginFormGlassMorphism.html"
       },
       {
         id: 7,


### PR DESCRIPTION
# 🚀 Pull Request

## 📄 Description
Initially when clicked on view Template of Login/Signup form in Templates Gallery it was directed to page not found. So in this PR i have added that page which it should link to when clicked on view template of Login/SignUp form..
Fixes #{1300}

## 🛠️ Type of Change
- [ ] Bug fix 🐛

## ✅ Checklist
- [ ]My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have linked the issue using `Fixes #1300 `