### PR TITLE
 Enable users to mark templates as favorites

### DIFF
--- a/templates.css
+++ b/templates.css
@@ -585,3 +585,21 @@ input:checked + .slider:before {
   }
 }
 /* </style> */
+
+/* Favorite button styling */
+.favorite-btn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 1.2rem;
+  color: #ccc;
+  transition: transform 0.2s ease, color 0.2s ease;
+}
+
+.favorite-btn:hover {
+  transform: scale(1.2);
+  color: gold;
+}

--- a/templates.html
+++ b/templates.html
@@ -8,7 +8,9 @@
       name="description"
       content="A comprehensive collection of CSS animation templates and effects for web developers"
     />
-
+     <!-- Font Awesome for icons -->
+     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
+     <link rel="stylesheet" href="templates.css" />
     <!-- PWA Meta Tags -->
     <meta name="theme-color" content="#ff6b6b" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
@@ -228,6 +230,7 @@
             Landing Pages
           </button>
           <button class="filter-btn" data-filter="other">Other</button>
+          <button class="filter-btn" data-filter="favorites">⭐ Favorites</button>
         </div>
       </div>
 
@@ -451,7 +454,7 @@
         }
 
         templatesToRender.forEach((template) => {
-          const templateCard = document.createElement("a");
+          const templateCard = document.createElement("div");
           templateCard.href = template.link;
           templateCard.className = "template-card";
           templateCard.setAttribute("data-category", template.category);
@@ -459,6 +462,9 @@
           templateCard.innerHTML = `
           <div class="template-preview">
             <i class="${template.icon}"></i>
+             <button class="favorite-btn" data-id="${template.id}" title="Add to Favorites">
+             <i class="far fa-star"></i>
+           </button>
           </div>
           <div class="template-content">
             <h2>${template.title}</h2>
@@ -466,14 +472,55 @@
             <div class="template-tags">
               <span class="template-tag">${template.category}</span>
             </div>
-            <div class="template-btn">View Template</div>
+           <a href="${template.link}" class="template-btn">View Template</a>
           </div>
         `;
 
           templatesGrid.appendChild(templateCard);
         });
-      }
+        // Attach favorite button listeners
+        document.querySelectorAll(".favorite-btn").forEach((btn) => {
+                btn.addEventListener("click", toggleFavorite);
+            });
 
+            updateFavoriteUI();
+      }
+      // Load favorites from localStorage or initialize as empty array
+let favorites = JSON.parse(localStorage.getItem("favorites")) || [];
+
+// Function to toggle favorite
+function toggleFavorite(event) {
+    event.stopPropagation(); // Stop card click (if needed)
+    const templateId = parseInt(event.currentTarget.dataset.id);
+
+    if (favorites.includes(templateId)) {
+        favorites = favorites.filter((id) => id !== templateId);
+    } else {
+        favorites.push(templateId);
+    }
+
+    localStorage.setItem("favorites", JSON.stringify(favorites));
+    updateFavoriteUI();
+}
+
+      function updateFavoriteUI() {
+            document.querySelectorAll(".favorite-btn").forEach((btn) => {
+                const templateId = parseInt(btn.dataset.id);
+                const icon = btn.querySelector("i");
+
+                if (favorites.includes(templateId)) {
+                    icon.classList.remove("far");
+                    icon.classList.add("fas");
+                    icon.style.color = "gold";
+                    btn.title = "Remove from Favorites";
+                } else {
+                    icon.classList.remove("fas");
+                    icon.classList.add("far");
+                    icon.style.color = "inherit";
+                    btn.title = "Add to Favorites";
+                }
+            });
+        }
       // Setup event listeners
       function setupEventListeners() {
         // Search functionality
@@ -526,8 +573,12 @@
           const matchesSearch =
             template.title.toLowerCase().includes(searchTerm) ||
             template.description.toLowerCase().includes(searchTerm);
-          const matchesCategory =
+          let matchesCategory =
             activeFilter === "all" || template.category === activeFilter;
+              // Check for favorites filter
+              if (activeFilter === "favorites") {
+                    matchesCategory = favorites.includes(template.id);
+                }
 
           return matchesSearch && matchesCategory;
         });


### PR DESCRIPTION
# 🚀 Pull Request

## 📄 Description
<!-- Describe your changes in detail -->
Added a favorites feature to the templates gallery. Users can click the star icon on each template card to mark it as a favorite. Favorites are stored in localStorage and persist across page reloads. Updated filtering to include a Favorites filter button
Fixes #1356 

## 🛠️ Type of Change
- [x] New feature ✨

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have linked the issue using `Fixes #1356 `

## 📸 Screenshots (if available)
<!-- Add screenshots/gifs to explain what you changed -->
 ![image]  https://drive.google.com/file/d/12iiDGeMzzBvvF4_-Ds9NXA5W41ueP1XB/view?usp=drive_link

## 📚 Related Issues
#1356 
 

## 🧠 Additional Context
<!-- Any other information about this PR -->
Clicking the star updates UI dynamically.
Favorites filter displays only selected templates.
