### PR TITLE
Correct login link on sign-up page

### DIFF
--- a/loginpage.html
+++ b/loginpage.html
@@ -26,7 +26,7 @@
       <button type="submit" class="btn">Login</button>
     </form>
 
-    <p class="switch">Don’t have an account? <a href="signup.html">Sign up here</a></p>
+    <p class="switch">Don't have an account? <a href="signup.html">Sign up here</a></p>
   </section>
 </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -12,7 +12,7 @@
     <div class="logo">AnimateItNow</div>
     <ul class="nav-links">
       <li><a href="index.html">Home</a></li>
-      <li><a href="login.html">Login</a></li>
+      <li><a href="loginpage.html">Login</a></li>
     </ul>
   </nav>
 

--- a/templates/register.html
+++ b/templates/register.html
@@ -212,7 +212,7 @@
             <button type="submit">Register</button>
 
             <div class="login-link">
-              <p>Already have an account? <a href="login.html" id="loginLink">Login</a></p>
+              <p>Already have an account? <a href="LoginFormGlassMorphism.html" id="loginLink">Login</a></p>
             </div>
           </form>
         </div>


### PR DESCRIPTION
 Description
This pull request fixes the 404 "Page not found" error that occurred when a user clicked the "Login here" link on the sign-up page. The href attribute of the link has been updated to correctly point to the login page.

Fixes #1414 

Type of Change
Bug fix

https://github.com/user-attachments/assets/d104581a-1e6d-4729-88cb-eb619b563c0b

Fixed the rerouting error from the signup page to the login page  