### PR TITLE
Fix: Ensured mobile navbar integrity by hiding desktop action buttons…

### DIFF
--- a/index.html
+++ b/index.html
@@ -1185,7 +1185,20 @@
             .nav-links li {
                 margin: 10px 0;
             }
+            .nav-actions .btn, .nav-actions .btn-outline {
+                display: none; 
+            }
+            .nav-actions {
+                display: flex; 
+                gap: 15px;
+            }
             
+            .nav-links {
+                
+                display: none;
+               
+            }
+
             .hamburger {
                 display: flex;
             }


### PR DESCRIPTION
… on screens 768px and below. Fixes #1446
# 🚀 Pull Request

## 📄 Description
This PR fixes the mobile navigation overlap reported in **Issue #1446** for screen sizes 768px and below (tablet/mobile view).

The desktop action buttons ("Login" and "Sign Up") were causing the header content to break and overlap the logo before the mobile menu fully engaged.

The solution hides these two large buttons when the viewport shrinks to 768px or less, ensuring only the **Logo**, **Theme Toggle**, and **Hamburger Button** are visible, preserving the integrity and usability of the navigation bar on small devices.

Fixes **#1446**

## 🛠️ Type of Change
- [X] Bug fix 🐛
- [ ] New feature ✨
- [ ] Code refactor 🔨
- [ ] Documentation update 📚
- [ ] Other (please describe):

## ✅ Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have linked the issue using `Fixes #1446`

## 📸 Screenshots (if available)
<img width="400" height="500" alt="Screenshot 2025-10-05 154137" src="https://github.com/user-attachments/assets/24fa794a-2724-47a6-a372-44631dd77cae" />


## 📚 Related Issues
N/A

## 🧠 Additional Context
This fix leverages the existing `@media (max-width: 768px)` block to hide the `.nav-actions .btn` elements, relying on the links within the mobile menu (`.nav-links`) for access to login/signup pages on mobile.